### PR TITLE
David tunes robot  align command

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -4,6 +4,8 @@
 
 package frc.robot;
 
+import java.util.function.Supplier;
+
 import com.pathplanner.lib.config.PIDConstants;
 
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
@@ -16,6 +18,8 @@ import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import swervelib.math.Matter;
 import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 
@@ -39,6 +43,7 @@ public final class Constants
     public static final double kExpo = 4; //do not change this value
     public static final double kExpoRatio = 0.5; // change this 0..1 to add more exponential, 0 = no expo (linear)
     public static final double kDeadband = 0.07;
+    public static final Supplier<Alliance> kAlliance = () -> (DriverStation.getAlliance().isPresent()) ? DriverStation.getAlliance().get() : Alliance.Red;
   }
   /**
    * Constants for the swerve system.
@@ -49,8 +54,8 @@ public final class Constants
     // public static final String  kJsonDirectory = "pancake";
     public static final String  kJsonDirectory = "nori";
     public static final double kMaxSpeedMetersPerSecond = 5.06;
-    public static final double kRobotMass = Units.lbsToKilograms(120); // TODO: update
-    public static final Matter kChassisMatter = new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), kRobotMass); // TODO: update
+    public static final double kRobotMass = Units.lbsToKilograms(115); // TODO: update
+    public static final Matter kChassisMatter = new Matter(new Translation3d(0, 0, Units.inchesToMeters(7)), kRobotMass); // TODO: update
     public static final double kLoopTime = 0.13; //s, 20ms + 110ms sprk max velocity lag
   }
   /**
@@ -104,7 +109,7 @@ public final class Constants
 
   public static final class CommandConstants {
     public static final class AimAtLimeLightConstants {
-      public static final double maxTimeSeconds = 10;
+      public static final double maxTimeSeconds = 4;
       public static final double kP = 0.01;
       public static final double kI = 0.0;
       public static final double kD = 0.0;
@@ -124,7 +129,7 @@ public final class Constants
       /**
        * How much the robot should be offset from the April tag pose x direction.
       */
-      public static final double transformDrive = 0.5;
+      public static final double transformDrive = 0.1; // Was 0.5
 
       public static final double coralOffset = (13.25 / 2) * 0.0254;
       public static final double outTakeOffset = (3.25) * 0.0254;
@@ -133,8 +138,8 @@ public final class Constants
        * How much the robot should be offset from the April tag pose y direction.
       */
       public static final double transformStrafe = 3.25 / 12; // 3.25 inches offset
-      public static final double transformLeftStrafe = -coralOffset - outTakeOffset;
-      public static final double transformRightStrafe = coralOffset - outTakeOffset;
+      public static final double transformLeftStrafe = -0.22 - 0.15; // Was coralOffset - outTakeOffset, -18
+      public static final double transformRightStrafe = -0.22 + 0.15; // Was -coralOffset - outTakeOffset, -72
     }
 
     public static final class AimAtLimeLightV2Constants {
@@ -187,11 +192,11 @@ public final class Constants
     public static final int kArmEncoderID = 9;
     public static final double kArmGearBoxRatio = 125 * (44/30);
 
-    public static final double kMaxArmRotation = 3.5;
+    public static final double kMaxArmRotation = 3.7;
     public static final double L1ArmAngle = 0.8;
-    public static final double kMinArmRotation = 0.7;
+    public static final double kMinArmRotation = 0.9;
     
-    public static final double kAbsoluteEncoderOffset = 0;
+    public static final double kAbsoluteEncoderOffset = 2.4;
     public static final int kcurrentLimit = 20;
     public static final double tolerance = 0.1;
     public static final double setArmMaxTime = 4;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -205,19 +205,23 @@ public class RobotContainer
     AlignRobotConstants.transformLeftStrafe
   ));
     m_driverController.povRight().onTrue(m_swerveDrive.alignWithAprilTagCommand(
-    AlignRobotConstants.transformDrive,
-    AlignRobotConstants.transformRightStrafe
+      AlignRobotConstants.transformDrive,
+      AlignRobotConstants.transformRightStrafe
   ));
 
 
     // Command to spit out game pieces
-    m_armController.a().onTrue(new IntakeSpitCommand(m_intakeSystem, IntakeSpitCommandConstants.speed));
+    m_armController.a().whileTrue(new IntakeSpitCommand(m_intakeSystem, IntakeSpitCommandConstants.speed));
 
     m_armController.b().onTrue(new OuttakeSpitCommand(m_outtakeSystem));
 
     m_armController.povDown().onTrue(new ElevatorToPositionCommand(m_elevatorSystem, ElevatorConstants.kDownElevatorPosition));
     m_armController.x().onTrue(new ElevatorToPositionCommand(m_elevatorSystem, ElevatorConstants.kLevel2ReefPosition));
     m_armController.y().onTrue(new ElevatorToPositionCommand(m_elevatorSystem, ElevatorConstants.kLevel3ReefPosition));
+
+    new Trigger(() -> (m_driverController.leftBumper().getAsBoolean() && m_swerveDrive.getVisionSystem().isDetecting())).onTrue(
+      Commands.runOnce(() -> m_swerveDrive.trueResetPose())
+    );
 
 
     // Test mode has (b) button triggering a test sequence

--- a/src/main/java/frc/robot/subsystems/IntakeArmSystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeArmSystem.java
@@ -1,7 +1,5 @@
 package frc.robot.subsystems;
 
-import org.dyn4j.exception.ValueOutOfRangeException;
-
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkBase;
 import com.revrobotics.spark.SparkClosedLoopController;
@@ -67,9 +65,9 @@ public class IntakeArmSystem extends SubsystemBase{
             m_armRelativeEncoder.setPosition(getArmAngle());
         }
 
-        if (!m_armEncoder.isConnected()) {
-            throw new ValueOutOfRangeException("ARM ABSOLUTE ENCODER NOT PLUGGED IN!", m_armEncoder.get());
-        }
+        // if (!m_armEncoder.isConnected()) {
+        //     throw new ValueOutOfRangeException("ARM ABSOLUTE ENCODER NOT PLUGGED IN!", m_armEncoder.get());
+        // }
         desiredAngle = getArmAngleRelative();
 
         initShuffleboard();
@@ -87,6 +85,7 @@ public class IntakeArmSystem extends SubsystemBase{
         tab.addDouble("Arm Relative Encoder", () -> getArmAngleRelative());
         tab.addDouble("Arm Encoder", () -> getArmAngle());
         tab.addDouble("Desired Angle", () -> desiredAngle);
+        tab.addBoolean("Encoder Is Connected", () -> m_armEncoder.isConnected());
   }
 
     public void setReference(double position) {

--- a/src/main/java/frc/robot/vision/VisionSystem.java
+++ b/src/main/java/frc/robot/vision/VisionSystem.java
@@ -5,6 +5,8 @@ import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import frc.robot.Constants.VisionConstants;
 
 public class VisionSystem implements VisionSystemInterface {
@@ -23,7 +25,14 @@ public class VisionSystem implements VisionSystemInterface {
     // Constructor
     public VisionSystem() {
         // Empty
-        
+        initShuffleboad();
+    }
+
+    public void initShuffleboad() {
+        ShuffleboardTab tab = Shuffleboard.getTab("Vision");
+        tab.addDouble("Robot Pose X", () -> getRobotPose().getX());
+        tab.addDouble("Robot Pose Y", () -> getRobotPose().getY());
+        tab.addDouble("Robot Pose Rot", () -> getRobotPose().getRotation().getDegrees());
     }
 
     @Override
@@ -50,7 +59,7 @@ public class VisionSystem implements VisionSystemInterface {
 
     @Override
     public boolean isDetecting() {
-        return (getTX() + getTY() + getTA()) != 0;
+        return getTA() > 0.1;
     }
 
     @Override
@@ -76,7 +85,7 @@ public class VisionSystem implements VisionSystemInterface {
 
     private Pose2d calcRobotPoseHelper() {
         if (isDetecting()) {
-            return LimelightHelpers.getBotPose2d_wpiBlue(VisionConstants.limelightName);
+            return LimelightHelpers.getBotPoseEstimate_wpiBlue(VisionConstants.limelightName).pose;
         }
         return new Pose2d();
     }


### PR DESCRIPTION
Correct arm offsets to actual values.

Show if encoder is connected in shuffleboard.

Code for fixing auto align.

Add command to update current pose in match based on limelight data. Limelight is not getting correct robot pose.

DIsplay vision pose on shuffleboard and whether vision system is for simulation. Fix logic for getting alliance.

Temporarily disabled arm

Auto alignment left works

Offsets are a bit too much to the left.

Fix alliance selection.

Increase alignment acceleration.

Work on offsets for auto align.

Add offset for arm values in code.

Correct error where aligning from right to left of the field does not work.

Can align from any position. Offsets need to be adgusted.

Allow holding the b button to spit out continuously.

Use radians instead of degrees for align robot function to fix conversion error.

Good constants for right strafe.

Can align correctly on left.

Offset for right alignment usually works.

Align with drive better.
Make code a bit more readable

Undo changes to simgui files