### PR TITLE
Arm Simulation (no code change outside of RobotBase.isSimulation())

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -1,208 +1,208 @@
-{
-  "NTProvider": {
-    "types": {
-      "/FMSInfo": "FMSInfo",
-      "/Shuffleboard/Autos/Auto Selector": "String Chooser",
-      "/Shuffleboard/Field/Robot Position on Field": "Field2d",
-      "/Shuffleboard/Field/Target Position on Field": "Field2d",
-      "/Shuffleboard/Test/Angle Test": "Command",
-      "/Shuffleboard/Test/Spin Test": "Command",
-      "/SmartDashboard/Alerts": "Alerts",
-      "/SmartDashboard/Encoders": "Alerts",
-      "/SmartDashboard/Field": "Field2d",
-      "/SmartDashboard/IMU": "Alerts",
-      "/SmartDashboard/JSON": "Alerts",
-      "/SmartDashboard/Motors": "Alerts",
-      "/SmartDashboard/Pigeon 2 (v6) [18]": "Gyro",
-      "/SmartDashboard/Swerve Drive": "Alerts",
-      "/SmartDashboard/VisionSystemSim-main/Sim Field": "Field2d"
-    },
-    "windows": {
-      "/Shuffleboard/Autos/Auto Selector": {
-        "window": {
-          "visible": true
-        }
-      },
-      "/Shuffleboard/Field/Robot Position on Field": {
-        "bottom": 1638,
-        "builtin": "2025 Reefscape",
-        "height": 8.051901817321777,
-        "left": 534,
-        "right": 3466,
-        "top": 291,
-        "width": 17.54825210571289,
-        "window": {
-          "visible": true
-        }
-      },
-      "/SmartDashboard/VisionSystemSim-main/Sim Field": {
-        "EstimatedRobot": {
-          "arrowWeight": 3.0,
-          "length": 0.800000011920929,
-          "selectable": false,
-          "weight": 3.0,
-          "width": 0.800000011920929
-        },
-        "EstimatedRobotModules": {
-          "arrows": false,
-          "image": "swerve_module.png",
-          "length": 0.30000001192092896,
-          "selectable": false,
-          "width": 0.30000001192092896
-        },
-        "Robot": {
-          "arrowColor": [
-            1.0,
-            1.0,
-            1.0,
-            255.0
-          ],
-          "arrowWeight": 2.0,
-          "color": [
-            1.0,
-            1.0,
-            1.0,
-            255.0
-          ],
-          "length": 0.800000011920929,
-          "selectable": false,
-          "weight": 2.0,
-          "width": 0.800000011920929
-        },
-        "VisionEstimation": {
-          "arrowColor": [
-            0.0,
-            0.6075949668884277,
-            1.0,
-            255.0
-          ],
-          "arrowWeight": 2.0,
-          "color": [
-            0.0,
-            0.6075949668884277,
-            1.0,
-            255.0
-          ],
-          "selectable": false,
-          "weight": 2.0
-        },
-        "apriltag": {
-          "arrows": false,
-          "image": "tag-green.png",
-          "length": 0.6000000238418579,
-          "width": 0.5
-        },
-        "bottom": 1638,
-        "builtin": "2025 Reefscape",
-        "cameras": {
-          "arrowColor": [
-            0.29535865783691406,
-            1.0,
-            0.9910804033279419,
-            255.0
-          ],
-          "arrowSize": 19,
-          "arrowWeight": 3.0,
-          "length": 1.0,
-          "style": "Hidden",
-          "weight": 1.0,
-          "width": 1.0
-        },
-        "height": 8.051901817321777,
-        "left": 534,
-        "right": 3466,
-        "top": 291,
-        "visibleTargetPoses": {
-          "arrows": false,
-          "image": "tag-blue.png",
-          "length": 0.5,
-          "selectable": false,
-          "width": 0.4000000059604645
-        },
-        "width": 17.54825210571289,
-        "window": {
-          "visible": true
-        }
-      }
-    }
-  },
-  "NetworkTables": {
-    "transitory": {
-      "CameraPublisher": {
-        "YOUR CAMERA NAME-processed": {
-          "open": true,
-          "string[]##v_/CameraPublisher/YOUR CAMERA NAME-processed/streams": {
-            "open": true
-          }
-        }
-      },
-      "SmartDashboard": {
-        "VisionSystemSim-main": {
-          "Sim Field": {
-            "double[]##v_/SmartDashboard/VisionSystemSim-main/Sim Field/apriltag": {
-              "open": true
-            },
-            "double[]##v_/SmartDashboard/VisionSystemSim-main/Sim Field/visibleTargetPoses": {
-              "open": true
-            }
-          },
-          "open": true
-        },
-        "open": true
-      },
-      "photonvision": {
-        "YOUR CAMERA NAME": {
-          "Transform3d##v_/photonvision/YOUR CAMERA NAME/targetPose": {
-            "Rotation3d##v_rotation": {
-              "Quaternion##v_q": {
-                "open": true
-              },
-              "open": true
-            },
-            "Translation3d##v_translation": {
-              "open": true
-            },
-            "open": true
-          },
-          "open": true
-        },
-        "open": true
-      }
-    }
-  },
-  "NetworkTables Info": {
-    "visible": true
-  },
-  "NetworkTables View": {
-    "visible": false
-  },
-  "Plot": {
-    "Plot <0>": {
-      "plots": [
-        {
-          "backgroundColor": [
-            0.0,
-            0.0,
-            0.0,
-            0.8500000238418579
-          ],
-          "height": 332,
-          "series": [
-            {
-              "color": [
-                0.2980392277240753,
-                0.44705885648727417,
-                0.6901960968971252,
-                1.0
-              ],
-              "id": "NT:/SmartDashboard/Vision Target Visible"
-            }
-          ]
-        }
-      ],
-      "window": {
-        "visible": false
-      }
-    }
-  }
-}
+{ 
+  "NTProvider": { 
+    "types": { 
+      "/FMSInfo": "FMSInfo", 
+      "/Shuffleboard/Autos/Auto Selector": "String Chooser", 
+      "/Shuffleboard/Field/Robot Position on Field": "Field2d", 
+      "/Shuffleboard/Field/Target Position on Field": "Field2d", 
+      "/Shuffleboard/Test/Angle Test": "Command", 
+      "/Shuffleboard/Test/Spin Test": "Command", 
+      "/SmartDashboard/Alerts": "Alerts", 
+      "/SmartDashboard/Encoders": "Alerts", 
+      "/SmartDashboard/Field": "Field2d", 
+      "/SmartDashboard/IMU": "Alerts", 
+      "/SmartDashboard/JSON": "Alerts", 
+      "/SmartDashboard/Motors": "Alerts", 
+      "/SmartDashboard/Pigeon 2 (v6) [18]": "Gyro", 
+      "/SmartDashboard/Swerve Drive": "Alerts", 
+      "/SmartDashboard/VisionSystemSim-main/Sim Field": "Field2d" 
+    }, 
+    "windows": { 
+      "/Shuffleboard/Autos/Auto Selector": { 
+        "window": { 
+          "visible": true 
+        } 
+      }, 
+      "/Shuffleboard/Field/Robot Position on Field": { 
+        "bottom": 1638, 
+        "builtin": "2025 Reefscape", 
+        "height": 8.051901817321777, 
+        "left": 534, 
+        "right": 3466, 
+        "top": 291, 
+        "width": 17.54825210571289, 
+        "window": { 
+          "visible": true 
+        } 
+      }, 
+      "/SmartDashboard/VisionSystemSim-main/Sim Field": { 
+        "EstimatedRobot": { 
+          "arrowWeight": 3.0, 
+          "length": 0.800000011920929, 
+          "selectable": false, 
+          "weight": 3.0, 
+          "width": 0.800000011920929 
+        }, 
+        "EstimatedRobotModules": { 
+          "arrows": false, 
+          "image": "swerve_module.png", 
+          "length": 0.30000001192092896, 
+          "selectable": false, 
+          "width": 0.30000001192092896 
+        }, 
+        "Robot": { 
+          "arrowColor": [ 
+            1.0, 
+            1.0, 
+            1.0, 
+            255.0 
+          ], 
+          "arrowWeight": 2.0, 
+          "color": [ 
+            1.0, 
+            1.0, 
+            1.0, 
+            255.0 
+          ], 
+          "length": 0.800000011920929, 
+          "selectable": false, 
+          "weight": 2.0, 
+          "width": 0.800000011920929 
+        }, 
+        "VisionEstimation": { 
+          "arrowColor": [ 
+            0.0, 
+            0.6075949668884277, 
+            1.0, 
+            255.0 
+          ], 
+          "arrowWeight": 2.0, 
+          "color": [ 
+            0.0, 
+            0.6075949668884277, 
+            1.0, 
+            255.0 
+          ], 
+          "selectable": false, 
+          "weight": 2.0 
+        }, 
+        "apriltag": { 
+          "arrows": false, 
+          "image": "tag-green.png", 
+          "length": 0.6000000238418579, 
+          "width": 0.5 
+        }, 
+        "bottom": 1638, 
+        "builtin": "2025 Reefscape", 
+        "cameras": { 
+          "arrowColor": [ 
+            0.29535865783691406, 
+            1.0, 
+            0.9910804033279419, 
+            255.0 
+          ], 
+          "arrowSize": 19, 
+          "arrowWeight": 3.0, 
+          "length": 1.0, 
+          "style": "Hidden", 
+          "weight": 1.0, 
+          "width": 1.0 
+        }, 
+        "height": 8.051901817321777, 
+        "left": 534, 
+        "right": 3466, 
+        "top": 291, 
+        "visibleTargetPoses": { 
+          "arrows": false, 
+          "image": "tag-blue.png", 
+          "length": 0.5, 
+          "selectable": false, 
+          "width": 0.4000000059604645 
+        }, 
+        "width": 17.54825210571289, 
+        "window": { 
+          "visible": true 
+        } 
+      } 
+    } 
+  }, 
+  "NetworkTables": { 
+    "transitory": { 
+      "CameraPublisher": { 
+        "YOUR CAMERA NAME-processed": { 
+          "open": true, 
+          "string[]##v_/CameraPublisher/YOUR CAMERA NAME-processed/streams": { 
+            "open": true 
+          } 
+        } 
+      }, 
+      "SmartDashboard": { 
+        "VisionSystemSim-main": { 
+          "Sim Field": { 
+            "double[]##v_/SmartDashboard/VisionSystemSim-main/Sim Field/apriltag": { 
+              "open": true 
+            }, 
+            "double[]##v_/SmartDashboard/VisionSystemSim-main/Sim Field/visibleTargetPoses": { 
+              "open": true 
+            } 
+          }, 
+          "open": true 
+        }, 
+        "open": true 
+      }, 
+      "photonvision": { 
+        "YOUR CAMERA NAME": { 
+          "Transform3d##v_/photonvision/YOUR CAMERA NAME/targetPose": { 
+            "Rotation3d##v_rotation": { 
+              "Quaternion##v_q": { 
+                "open": true 
+              }, 
+              "open": true 
+            }, 
+            "Translation3d##v_translation": { 
+              "open": true 
+            }, 
+            "open": true 
+          }, 
+          "open": true 
+        }, 
+        "open": true 
+      } 
+    } 
+  }, 
+  "NetworkTables Info": { 
+    "visible": true 
+  }, 
+  "NetworkTables View": { 
+    "visible": false 
+  }, 
+  "Plot": { 
+    "Plot <0>": { 
+      "plots": [ 
+        { 
+          "backgroundColor": [ 
+            0.0, 
+            0.0, 
+            0.0, 
+            0.8500000238418579 
+          ], 
+          "height": 332, 
+          "series": [ 
+            { 
+              "color": [ 
+                0.2980392277240753, 
+                0.44705885648727417, 
+                0.6901960968971252, 
+                1.0 
+              ], 
+              "id": "NT:/SmartDashboard/Vision Target Visible" 
+            } 
+          ] 
+        } 
+      ], 
+      "window": { 
+        "visible": false 
+      } 
+    } 
+  } 
+} 

--- a/src/main/java/frc/robot/commands/ArmDefaultCommand.java
+++ b/src/main/java/frc/robot/commands/ArmDefaultCommand.java
@@ -3,6 +3,7 @@ package frc.robot.commands;
 import java.util.function.Supplier;
 
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.ArmConstants;
 import frc.robot.Constants.ArmDefaultCommandConstants;
@@ -22,11 +23,35 @@ public class ArmDefaultCommand extends Command {
     @Override
     public void initialize() {
         desiredAngle = m_armSystem.getArmAngleRelative();
+
+        // Call setPoint to set the arm-motor PID loop to the desired angle.
+        setArmAngle(desiredAngle);
     }
 
     @Override
     public void execute() {
-        setArmAngle(m_armSystem.getArmAngleRelative() + (m_deltaArmAngleFromController.get() / ArmDefaultCommandConstants.armAngleChangeRate));
+        if (RobotBase.isSimulation()) {
+            // NOTE: Fixed a bug where the desiredAngle was being updated based on the CURRENT position
+            // of the arm.  That means every time execute() was called, it was setting a new setpoint
+            // in the arm-motor.  The problem is that the arm-motor was already in a closed-loop PID control mode.
+            // So we should ONLY set the SetPoint if the joystick is moved.
+            // Also, we don't want things like gravity on the arm to cause it to slowly change the setpoint
+            // downward.  Instead, the setpoint should remain constant until the joystick is moved.
+            double deltaControllerValue = m_deltaArmAngleFromController.get() / ArmDefaultCommandConstants.armAngleChangeRate;
+
+            // Only tell arm (which already uses a closed loop PID controller) to move if
+            // joystick is moved
+            if (deltaControllerValue != 0) {
+                desiredAngle += deltaControllerValue;
+                setArmAngle(desiredAngle);
+            }
+
+            return;
+        }
+
+        // $TODO - See bugfix made for simulation above.  We should fix this for the actual physical robot too.
+        // Needs investigation.
+        setArmAngle(m_armSystem.getArmAngleRelative() + (m_deltaArmAngleFromController.get() / ArmDefaultCommandConstants.armAngleChangeRate)); 
     }
 
     @Override

--- a/src/main/java/frc/robot/commands/ArmTestCommand.java
+++ b/src/main/java/frc/robot/commands/ArmTestCommand.java
@@ -1,39 +1,39 @@
-package frc.robot.commands;
-
-import java.util.function.Supplier;
-
-import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.subsystems.IntakeArmSystem;
-
-//Command for testing arm woithout relying on PID
-public class ArmTestCommand extends Command {
-    private IntakeArmSystem m_armSystem;
-    private Supplier<Double> m_deltaArmAngleFromController;
-
-    public ArmTestCommand(IntakeArmSystem armSystem, Supplier<Double> deltaArmAngleFromController){
-        m_armSystem = armSystem;
-        m_deltaArmAngleFromController = deltaArmAngleFromController;
-
-        addRequirements(m_armSystem);
-    }
-
-    @Override
-    public void initialize(){
-
-    }
-
-    @Override
-    public void execute(){
-        m_armSystem.setArmMotorSpeed(m_deltaArmAngleFromController.get());
-    }
-
-    @Override
-    public boolean isFinished(){
-        return false;
-    }
-
-    @Override
-    public void end(boolean interrupted){
-        
-    }
-}
+package frc.robot.commands; 
+ 
+import java.util.function.Supplier; 
+ 
+import edu.wpi.first.wpilibj2.command.Command; 
+import frc.robot.subsystems.IntakeArmSystem; 
+ 
+//Command for testing arm woithout relying on PID 
+public class ArmTestCommand extends Command { 
+    private IntakeArmSystem m_armSystem; 
+    private Supplier<Double> m_deltaArmAngleFromController; 
+ 
+    public ArmTestCommand(IntakeArmSystem armSystem, Supplier<Double> deltaArmAngleFromController){ 
+        m_armSystem = armSystem; 
+        m_deltaArmAngleFromController = deltaArmAngleFromController; 
+ 
+        addRequirements(m_armSystem); 
+    } 
+ 
+    @Override 
+    public void initialize(){ 
+ 
+    } 
+ 
+    @Override 
+    public void execute(){ 
+        m_armSystem.setArmMotorSpeed(m_deltaArmAngleFromController.get()); 
+    } 
+ 
+    @Override 
+    public boolean isFinished(){ 
+        return false; 
+    } 
+ 
+    @Override 
+    public void end(boolean interrupted){ 
+         
+    } 
+} 

--- a/src/main/java/frc/robot/subsystems/IntakeArmSystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeArmSystem.java
@@ -1,147 +1,218 @@
-package frc.robot.subsystems;
-
-import com.revrobotics.RelativeEncoder;
-import com.revrobotics.spark.SparkBase;
-import com.revrobotics.spark.SparkClosedLoopController;
-import com.revrobotics.spark.SparkLowLevel.MotorType;
-import com.revrobotics.spark.config.ClosedLoopConfig;
-import com.revrobotics.spark.config.EncoderConfig;
-import com.revrobotics.spark.config.SparkBaseConfig;
-import com.revrobotics.spark.config.SparkMaxConfig;
-import com.revrobotics.spark.SparkMax;
-import com.revrobotics.spark.SparkBase.ControlType;
-
+package frc.robot.subsystems; 
+ 
+import com.revrobotics.RelativeEncoder; 
+import com.revrobotics.spark.SparkBase; 
+import com.revrobotics.spark.SparkClosedLoopController; 
+import com.revrobotics.spark.SparkLowLevel.MotorType; 
+import com.revrobotics.spark.config.ClosedLoopConfig; 
+import com.revrobotics.spark.config.EncoderConfig; 
+import com.revrobotics.spark.config.SparkBaseConfig; 
+import com.revrobotics.spark.config.SparkMaxConfig; 
+import com.revrobotics.spark.SparkMax; 
+import com.revrobotics.spark.SparkBase.ControlType; 
+ 
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
-import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard; 
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
-
+import edu.wpi.first.wpilibj.simulation.DutyCycleEncoderSim;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.SubsystemBase; 
+ 
 import frc.robot.Constants.OperatorConstants;
-import frc.robot.Constants.ArmConstants;
+import frc.robot.commands.SetArmToAngleCommand;
+import frc.robot.subsystems.armsimulation.ArmDisplay;
+import frc.robot.subsystems.armsimulation.ArmSimulation;
+import frc.robot.subsystems.armsimulation.IOArmSim;
+import frc.robot.subsystems.armsimulation.IOArmSimInterface;
+import frc.robot.util.RangeConvert;
+import frc.robot.util.RelativeEncoderSim;
+import frc.robot.Constants.ArmConstants; 
+ 
+ 
+public class IntakeArmSystem extends SubsystemBase{ 
+    private SparkMax m_armMotor = new SparkMax(ArmConstants.kArmMotorID, MotorType.kBrushless); 
+    private RelativeEncoder m_armRelativeEncoder = m_armMotor.getEncoder(); 
+    private SparkMaxConfig m_armConfig = new SparkMaxConfig(); 
+    private double maxOutput = ArmConstants.maxOutput; 
+    private SparkClosedLoopController m_armPIDController = m_armMotor.getClosedLoopController(); 
+    private final DutyCycleEncoder m_armEncoder = new DutyCycleEncoder(ArmConstants.kArmEncoderID); 
+    private double desiredAngle; 
+ 
+    private ArmSimulation m_armSimulation = null; 
+    private ArmDisplay m_armDisplay = null; 
+ 
+    //sets the idle mode of both motors to kBrake and adds a smartCurrentLimit 
+    public IntakeArmSystem(){ 
+        m_armEncoder.setInverted(true); 
+        m_armEncoder.setDutyCycleRange(0, 1); 
+ 
+        ClosedLoopConfig closedLoopConfig = new ClosedLoopConfig(); 
+        closedLoopConfig 
+            .p(1) 
+            .i(0) 
+            .d(0); 
+        // closedLoopConfig.positionWrappingEnabled(true); 
+        // closedLoopConfig.positionWrappingMinInput(0); 
+        // closedLoopConfig.positionWrappingMaxInput(Math.PI * 2); 
+ 
+        EncoderConfig encoderConfig = new EncoderConfig(); 
+        encoderConfig.positionConversionFactor((Math.PI * 2) / ArmConstants.kArmGearBoxRatio); 
+        encoderConfig.velocityConversionFactor(((Math.PI * 2) / ArmConstants.kArmGearBoxRatio) / 60); 
+        // Did not set distance per rotation 
+ 
+        // m_armConfig.inverted(true); 
+ 
+        m_armConfig.idleMode(SparkBaseConfig.IdleMode.kCoast); 
+        //m_armConfig.idleMode(SparkBaseConfig.IdleMode.kBrake); 
+        m_armConfig.smartCurrentLimit(ArmConstants.kcurrentLimit); 
+ 
+        m_armConfig.apply(closedLoopConfig); 
+        m_armConfig.apply(encoderConfig); 
+ 
+        m_armMotor.configure(m_armConfig,  
+            SparkBase.ResetMode.kResetSafeParameters,  
+            SparkBase.PersistMode.kPersistParameters); 
 
-
-public class IntakeArmSystem extends SubsystemBase{
-    private SparkMax m_armMotor = new SparkMax(ArmConstants.kArmMotorID, MotorType.kBrushless);
-    private RelativeEncoder m_armRelativeEncoder = m_armMotor.getEncoder();
-    private SparkMaxConfig m_armConfig = new SparkMaxConfig();
-    private double maxOutput = ArmConstants.maxOutput;
-    private SparkClosedLoopController m_armPIDController = m_armMotor.getClosedLoopController();
-    private final DutyCycleEncoder m_armEncoder = new DutyCycleEncoder(ArmConstants.kArmEncoderID);
-    private double desiredAngle;
-
-    //sets the idle mode of both motors to kBrake and adds a smartCurrentLimit
-    public IntakeArmSystem(){
-        m_armEncoder.setInverted(true);
-        m_armEncoder.setDutyCycleRange(0, 1);
-
-        ClosedLoopConfig closedLoopConfig = new ClosedLoopConfig();
-        closedLoopConfig
-            .p(1)
-            .i(0)
-            .d(0);
-        // closedLoopConfig.positionWrappingEnabled(true);
-        // closedLoopConfig.positionWrappingMinInput(0);
-        // closedLoopConfig.positionWrappingMaxInput(Math.PI * 2);
-
-        EncoderConfig encoderConfig = new EncoderConfig();
-        encoderConfig.positionConversionFactor((Math.PI * 2) / ArmConstants.kArmGearBoxRatio);
-        encoderConfig.velocityConversionFactor(((Math.PI * 2) / ArmConstants.kArmGearBoxRatio) / 60);
-        // Did not set distance per rotation
-
-        // m_armConfig.inverted(true);
-
-        m_armConfig.idleMode(SparkBaseConfig.IdleMode.kCoast);
-        //m_armConfig.idleMode(SparkBaseConfig.IdleMode.kBrake);
-        m_armConfig.smartCurrentLimit(ArmConstants.kcurrentLimit);
-
-        m_armConfig.apply(closedLoopConfig);
-        m_armConfig.apply(encoderConfig);
-
-        m_armMotor.configure(m_armConfig, 
-            SparkBase.ResetMode.kResetSafeParameters, 
-            SparkBase.PersistMode.kPersistParameters);
-
-        if (!m_armEncoder.isConnected()) {
-            m_armRelativeEncoder.setPosition(0.0);
-        } else {
-            m_armRelativeEncoder.setPosition(getArmAngle());
+        if (RobotBase.isSimulation()) { 
+            RangeConvert rangesPhysicalAndSim = new RangeConvert( 
+                Units.radiansToDegrees(ArmConstants.kMinArmRotation), 
+                Units.radiansToDegrees(ArmConstants.kMaxArmRotation), 
+                -45.0, 
+                45.0, 
+                5.0, 
+                true); 
+        
+            m_armSimulation = createSim(rangesPhysicalAndSim); 
+            m_armDisplay = new ArmDisplay(rangesPhysicalAndSim); 
         }
 
-        // if (!m_armEncoder.isConnected()) {
-        //     throw new ValueOutOfRangeException("ARM ABSOLUTE ENCODER NOT PLUGGED IN!", m_armEncoder.get());
+        if (!m_armEncoder.isConnected()) { 
+            m_armRelativeEncoder.setPosition(0.0); 
+        } else { 
+            m_armRelativeEncoder.setPosition(getArmAngle()); 
+        } 
+ 
+        // if (!m_armEncoder.isConnected()) { 
+        //     throw new ValueOutOfRangeException("ARM ABSOLUTE ENCODER NOT PLUGGED IN!", m_armEncoder.get()); 
         // }
-        desiredAngle = getArmAngleRelative();
+        desiredAngle = getArmAngleRelative(); 
+ 
+        initShuffleboard(); 
+    } 
+ 
+// private int loop = 0; 
+ 
+    private ArmSimulation createSim(RangeConvert rangesPhysicalAndSim) { 
+        // Create sim wrappers for devices 
+        DutyCycleEncoderSim absEncoderSim = new DutyCycleEncoderSim(m_armEncoder); 
+        RelativeEncoderSim relEncoderSim = new RelativeEncoderSim(m_armRelativeEncoder); 
+ 
+        IOArmSimInterface ioArmSim = new IOArmSim( 
+            absEncoderSim, 
+            relEncoderSim, 
+            () -> Units.radiansToDegrees(desiredAngle)); 
+ 
+        return new ArmSimulation( 
+            ioArmSim, 
+            rangesPhysicalAndSim); 
+    } 
 
-        initShuffleboard();
+    @Override 
+    public void periodic() { 
+        // loop += 1; 
+        // if (loop % 50 == 0) { 
+        //     System.out.println("@@@@ Arm encoder=" + getArmAngleRelative() + ", desired="+desiredAngle); 
+        // } 
+        if (m_armEncoder.isConnected()) { 
+            m_armRelativeEncoder.setPosition(getArmAngle()); 
+        } 
+    } 
+ 
+    @Override 
+    public void simulationPeriodic() { 
+        if (m_armSimulation != null) { 
+            m_armSimulation.simulationPeriodic(); 
+            m_armDisplay.setAngle(getArmAngle()); 
+        } 
     }
 
-// private int loop = 0;
-
-    @Override
-    public void periodic() {
-        // loop += 1;
-        // if (loop % 50 == 0) {
-        //     System.out.println("@@@@ Arm encoder=" + getArmAngleRelative() + ", desired="+desiredAngle);
-        // }
-        if (m_armEncoder.isConnected()) {
-            m_armRelativeEncoder.setPosition(getArmAngle());
-        }
-    }
-
-    public void initShuffleboard() {
-        if (!OperatorConstants.kCompetitionMode) {
-            ShuffleboardTab tab = Shuffleboard.getTab("Arm");
-            tab.addDouble("Arm Relative Encoder", () -> getArmAngleRelative());
-            tab.addDouble("Arm Encoder", () -> getArmAngle());
-            tab.addDouble("Desired Angle", () -> desiredAngle);
-            tab.addBoolean("Encoder Is Connected", () -> m_armEncoder.isConnected());
-
-            // Show current command on shuffleboard
-            tab.addString(
-            "IntakeArmSystem Command",
-            () -> (this.getCurrentCommand() == null) ? "None"
+    public void initShuffleboard() { 
+        if (!OperatorConstants.kCompetitionMode) { 
+            ShuffleboardTab tab = Shuffleboard.getTab("Arm"); 
+            tab.addDouble("Arm Relative Encoder", () -> getArmAngleRelative()); 
+            tab.addDouble("Arm Encoder", () -> getArmAngle()); 
+            tab.addDouble("Desired Angle", () -> desiredAngle); 
+            tab.addBoolean("Encoder Is Connected", () -> m_armEncoder.isConnected()); 
+ 
+            // Show current command on shuffleboard 
+            tab.addString( 
+            "IntakeArmSystem Command", 
+            () -> (this.getCurrentCommand() == null) ? "None" 
                     : this.getCurrentCommand().getName());
-        }
-  }
 
-    public void setReference(double position) {
-        desiredAngle = position;
-        m_armPIDController.setReference(position, ControlType.kPosition);
-    }
-
-    //sets the speed of m_armMotor. Cannot exceed maxOutputPercentage
-    public void setArmMotorSpeed(double speed){
-        speed = MathUtil.clamp(speed, -maxOutput, maxOutput);
-        m_armMotor.set(speed);
-    }
-
-    //gets the speed of m_armMotor
-    public double getArmMotorSpeed(){
-        return m_armMotor.get();
-    }
-
-
-
-    // get encoder value
+            if (RobotBase.isSimulation()) { 
+                SmartDashboard.putData("Arm Sim", m_armDisplay.getMech2d()); 
+ 
+                // Add a button to test moving arm up 
+                Command goUp = new SetArmToAngleCommand(this, ArmConstants.kMinArmRotation); 
+                tab.add("Go Up2", goUp).withWidget("Command"); 
+ 
+                Command goDown = new SetArmToAngleCommand(this, ArmConstants.kMaxArmRotation); 
+                tab.add("Go Down2", goDown).withWidget("Command"); 
+ 
+                Command goL1 = new SetArmToAngleCommand(this, ArmConstants.L1ArmAngle); 
+                tab.add("Go L1", goL1).withWidget("Command"); 
+            } 
+        } 
+  } 
+ 
+    public void setReference(double position) { 
+        desiredAngle = position; 
+        m_armPIDController.setReference(position, ControlType.kPosition); 
+    } 
+ 
+    //sets the speed of m_armMotor. Cannot exceed maxOutputPercentage 
+    public void setArmMotorSpeed(double speed){ 
+        speed = MathUtil.clamp(speed, -maxOutput, maxOutput); 
+        m_armMotor.set(speed); 
+    } 
+ 
+    //gets the speed of m_armMotor 
+    public double getArmMotorSpeed(){ 
+        return m_armMotor.get(); 
+    } 
+ 
+ 
+ 
+    // get encoder value 
     private double getArmAngle() {
-        return Math.max(0, (m_armEncoder.get() * 2 * Math.PI) + ArmConstants.kAbsoluteEncoderOffset) % (Math.PI * 2);
-    }
+        if (RobotBase.isSimulation()) { 
+            return m_armEncoder.get(); 
+        }
 
-    public double getArmAngleRelative() {
-        return m_armRelativeEncoder.getPosition();
-    }
-
-    // public double getAbsoluteArmAngle() {
-    //     return m_armEncoder.getAbsolutePosition();
-    // }
-
-    // public void resetArmAngle() {
-    //     m_armEncoder.reset();
-    // }
-
-    //stops everything
-    public void stopSystem(){
-        m_armMotor.stopMotor();
-    }
-}
+        /// $TODO This seems like a bug.  Conversion factor was already configured on the absolute encoder, 
+        // so units are already in radians.  Needs investigation.
+        return Math.max(0, (m_armEncoder.get() * 2 * Math.PI) + ArmConstants.kAbsoluteEncoderOffset) % (Math.PI * 2); 
+    } 
+ 
+    public double getArmAngleRelative() { 
+        return m_armRelativeEncoder.getPosition(); 
+    } 
+ 
+    // public double getAbsoluteArmAngle() { 
+    //     return m_armEncoder.getAbsolutePosition(); 
+    // } 
+ 
+    // public void resetArmAngle() { 
+    //     m_armEncoder.reset(); 
+    // } 
+ 
+    //stops everything 
+    public void stopSystem(){ 
+        m_armMotor.stopMotor(); 
+    } 
+} 

--- a/src/main/java/frc/robot/subsystems/armsimulation/ArmDisplay.java
+++ b/src/main/java/frc/robot/subsystems/armsimulation/ArmDisplay.java
@@ -1,0 +1,47 @@
+package frc.robot.subsystems.armsimulation;
+
+import java.util.function.DoubleSupplier;
+
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
+import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
+import edu.wpi.first.wpilibj.smartdashboard.MechanismRoot2d;
+import edu.wpi.first.wpilibj.util.Color;
+import edu.wpi.first.wpilibj.util.Color8Bit;
+import frc.robot.util.RangeConvert;
+
+public class ArmDisplay {
+    private RangeConvert m_rangesPhysicalAndSim;
+    private Mechanism2d m_mech2d;
+    private MechanismLigament2d m_armLigament;
+
+    // Constructor
+    public ArmDisplay(RangeConvert rangesPhysicalAndSim) {
+        m_rangesPhysicalAndSim = rangesPhysicalAndSim;
+
+        // Create the arm display in ShuffleBoard
+        m_mech2d = new Mechanism2d(60, 60);
+        m_armLigament = createArmLigament(m_mech2d);
+    }
+
+    public Mechanism2d getMech2d() {
+        return m_mech2d;
+    }
+
+    // This takes as input the angle of the physical arm in radians.
+    public void setAngle(double physicalArmRads) {
+        double physicalArmDegrees = Units.radiansToDegrees(physicalArmRads);
+        double simArmDegrees = m_rangesPhysicalAndSim.physicalToSim(physicalArmDegrees);
+        m_armLigament.setAngle(simArmDegrees); 
+    }
+
+    private MechanismLigament2d createArmLigament(Mechanism2d mech2d) {
+        MechanismRoot2d armPivot = mech2d.getRoot("ArmPivot", 30, 30); 
+        MechanismLigament2d armTower = armPivot.append(new MechanismLigament2d("ArmTower", 20, -90));
+        MechanismLigament2d armLigament = armPivot.append( 
+            new MechanismLigament2d("Arm", 15, 0, 6, new Color8Bit(Color.kYellow)) 
+        );
+
+        return armLigament;
+    }
+}

--- a/src/main/java/frc/robot/subsystems/armsimulation/ArmSimulation.java
+++ b/src/main/java/frc/robot/subsystems/armsimulation/ArmSimulation.java
@@ -1,0 +1,121 @@
+package frc.robot.subsystems.armsimulation;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.math.util.Units; 
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
+import frc.robot.util.RangeConvert;
+
+// This class internally simulates an arm using a min-simulation-degrees to max-simulation-degrees
+// range.  This was chosen for one primary reason:
+//   1. Since the arm simulation uses gravity, its important that it simulate the exact
+//      range that we DISPLAY in mech2d.  Otherwise, the gravity will be wrong.
+//
+// Net-net: IOArmSim is always dealing in the PHYSICAL range of the arm.  But the arm
+// simulation is always dealing with the SIMULATION range.
+//
+// NOTE: When the robot is PHYSICALLY running, we re-use the mech2d to display the current
+// arm position.  So even in this case, we convert the phyical arm position to the
+// simulated range.
+//
+public class ArmSimulation {
+    private IOArmSimInterface m_ioArmSimInterface;
+ 
+    private PIDController m_pidController = new PIDController(1.0, 0.0, 0.0);
+
+    private SingleJointedArmSim m_armSim;
+
+    private RangeConvert m_rangesPhysicalAndSim;
+    
+    // Constructor
+    public ArmSimulation(
+        IOArmSimInterface ioArmSimInterface,
+        RangeConvert rangesPhysicalAndSim) {
+
+        if (!RobotBase.isSimulation()) {
+            System.out.println("ERROR: ArmSimulation is only available in simulation mode.");
+            return;
+        }
+
+        m_rangesPhysicalAndSim = rangesPhysicalAndSim;
+        if (m_rangesPhysicalAndSim.getMinPhysicalArmDegrees() >= m_rangesPhysicalAndSim.getMaxPhysicalArmDegrees()) {
+            throw new IllegalArgumentException("getMinPhysicalArmDegrees must be less than getMaxPhysicalArmDegrees");
+        }
+        if (m_rangesPhysicalAndSim.getMinSimDegrees() >= m_rangesPhysicalAndSim.getMaxSimDegrees()) {
+            throw new IllegalArgumentException("getMinSimDegrees must be less than getMaxSimDegrees");
+        }
+
+        m_ioArmSimInterface = ioArmSimInterface;
+
+        m_armSim = createSingleJointedArmSim();
+
+        initArmPosition();
+    }
+
+    // In simulation, the arm encoder is at 0, rather than at some reasonable
+    // arm position half-way up.  So we explicitely set the arm to a half-way
+    // point here.
+    private void initArmPosition() {
+        double halfwaySimDegrees = (m_rangesPhysicalAndSim.getMinSimDegrees() + m_rangesPhysicalAndSim.getMaxSimDegrees()) / 2.0;
+
+        double halfwayPhysicalDegrees = m_rangesPhysicalAndSim.simToPhysical(halfwaySimDegrees);
+
+        m_ioArmSimInterface.initPosition(halfwayPhysicalDegrees);
+    }
+
+    public void simulationPeriodic() {
+        // Read the setpoint from the IO 
+        double physicalDesiredAngleDegrees = m_ioArmSimInterface.getPhysicalSetpointDegrees();
+        double simDesiredAngleDegrees = m_rangesPhysicalAndSim.physicalToSim(physicalDesiredAngleDegrees);
+        // System.out.println("##### Arm setpoint degrees = " + simDesiredAngleDegrees);
+
+        double simDesiredAngleRads = Units.degreesToRadians(simDesiredAngleDegrees);
+        double currentAngleRads = m_armSim.getAngleRads();
+
+        // Use PID controller to get motor voltage.
+        //
+        // NOTE: The PID Controller assumes Radians for how it was tuned.  I didnt
+        // think it would matter, but when I tried using Degrees, the arm jittered around.
+        double simOutput = m_pidController.calculate(currentAngleRads, simDesiredAngleRads);
+        double motorVolts = MathUtil.clamp(simOutput, -1.0, 1.0) * 12.0;
+
+        // Run the simulation with a particular motor voltage
+        m_armSim.setInput(motorVolts);
+        m_armSim.update(0.02);
+
+        // Set the output
+        double newSimAngleDegrees = Units.radiansToDegrees(m_armSim.getAngleRads());
+
+        // Write the new position into the absolute encoder
+        double newPhysiclAngleDegrees = m_rangesPhysicalAndSim.simToPhysical(newSimAngleDegrees);
+        m_ioArmSimInterface.setPhysicalOutputArmDegreesAbsolute(newPhysiclAngleDegrees);
+    }
+
+    private SingleJointedArmSim createSingleJointedArmSim() {
+        // The arm gearbox represents a gearbox containing two Vex 775pro motors. 
+        DCMotor armGearbox = DCMotor.getVex775Pro(2);
+
+        double kArmReduction = 200;
+        double kArmLength = Units.inchesToMeters(20);
+        double kArmMass = 4.0; // Kilograms
+ 
+        // distance per pulse = (angle per revolution) / (pulses per revolution)
+        //  = (2 * PI rads) / (4096 pulses)
+        double kArmEncoderDistPerPulse = 2.0 * Math.PI / 4096;
+ 
+        return new SingleJointedArmSim( 
+            armGearbox,
+            kArmReduction, 
+            SingleJointedArmSim.estimateMOI(kArmLength, kArmMass),
+            kArmLength,
+            Units.degreesToRadians(m_rangesPhysicalAndSim.getMinSimDegrees()),
+            Units.degreesToRadians(m_rangesPhysicalAndSim.getMaxSimDegrees()),
+            true,
+            0,
+            kArmEncoderDistPerPulse,
+            0.0 // Add noise with a std-dev of 1 tick
+        ); 
+    }
+}

--- a/src/main/java/frc/robot/subsystems/armsimulation/IOArmSim.java
+++ b/src/main/java/frc/robot/subsystems/armsimulation/IOArmSim.java
@@ -1,0 +1,70 @@
+package frc.robot.subsystems.armsimulation;
+
+import java.util.function.DoubleSupplier;
+
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.simulation.DutyCycleEncoderSim;
+import frc.robot.util.RelativeEncoderSim;
+
+public class IOArmSim implements IOArmSimInterface {
+    private DutyCycleEncoderSim m_absEncoderSim;
+    private RelativeEncoderSim m_relEncoderSim;
+    private DoubleSupplier m_setpointSupplier;
+
+    // Constructor
+    public IOArmSim(
+        DutyCycleEncoderSim absEncoderSim,
+        RelativeEncoderSim relEncoderSim,
+        DoubleSupplier setpointSupplier) {
+
+        if (!RobotBase.isSimulation()) {
+            System.out.println("ERROR: IOArmSim should only be instantiated in simulation mode.");
+        }
+        if (absEncoderSim == null) {
+            System.out.println("ERROR: absEncoderSim is null");
+        }
+        if (relEncoderSim == null) {
+            System.out.println("ERROR: relEncoderSim is null");
+        }
+        if (setpointSupplier == null) {
+            System.out.println("ERROR: setpointSupplier is null");
+        }
+
+        m_absEncoderSim = absEncoderSim;
+        m_relEncoderSim = relEncoderSim;
+        m_setpointSupplier = setpointSupplier;
+    }
+
+    @Override
+    public void initPosition(double physicalAngleDegrees) {
+        // Were initializing the position of the arm in simulation.
+        m_absEncoderSim.set(Units.degreesToRadians(physicalAngleDegrees));
+
+        // Reset the relative encoder to 0.0
+        m_relEncoderSim.setPosition(0.0);
+    }
+
+    @Override
+    public double getPhysicalSetpointDegrees() {
+        return m_setpointSupplier.getAsDouble();
+    }
+
+    @Override
+    public void setPhysicalOutputArmDegreesAbsolute(double physicalAngleDegrees) {
+        // NOTE: Normally, encoders use Rotations for units.  But conversion factor
+        // was configured on the encoders to use radians.
+        double physicalAngleRads = Units.degreesToRadians(physicalAngleDegrees);
+
+        double previousPhysicalRads = m_absEncoderSim.get();
+
+        // Set new value on the absolute encoder sim object.
+        m_absEncoderSim.set(physicalAngleRads);
+
+        // Move relative encoder by the DELTA.
+        double delta = physicalAngleRads - previousPhysicalRads;
+
+        // Set it on the relative encoder sim object.
+        m_relEncoderSim.setPosition(m_relEncoderSim.getPosition() + delta);
+    }
+}

--- a/src/main/java/frc/robot/subsystems/armsimulation/IOArmSimInterface.java
+++ b/src/main/java/frc/robot/subsystems/armsimulation/IOArmSimInterface.java
@@ -1,0 +1,17 @@
+package frc.robot.subsystems.armsimulation;
+
+// This class is intended to give the SIMULATION implementation a
+// simpler interface to use.
+public interface IOArmSimInterface {
+    void initPosition(double physicalAngleDegrees);
+
+    //
+    // Inputs to the simulation
+    //
+    double getPhysicalSetpointDegrees();
+
+    //
+    // Outputs that the simulation calculates
+    //
+    void setPhysicalOutputArmDegreesAbsolute(double physicalAngleDegrees);
+}

--- a/src/main/java/frc/robot/util/RangeConvert.java
+++ b/src/main/java/frc/robot/util/RangeConvert.java
@@ -1,0 +1,98 @@
+package frc.robot.util;
+
+public class RangeConvert {
+    private final double m_minPhysicalArmDegrees;
+    private final double m_maxPhysicalArmDegrees;
+    private final double m_minSimDegrees;
+    private final double m_maxSimDegrees;
+    private final boolean m_inverted;
+    
+    // NOTE: We allow for a buffer in the min and max degrees to allow for a little bit of wiggle
+    // room in the simulation.  For example, the simulation has gravity pulling down on the arm, so
+    // if the robot purposefully moves the arm to the lowwest point, the simulated arm will actually
+    // droop a little bit below the lowest point.
+    public RangeConvert(
+        double minPhysicalArmDegrees,
+        double maxPhysicalArmDegrees,
+        double minSimDegrees,
+        double maxSimDegrees,
+        double bufferDegrees,
+        boolean inverted) {
+
+        if (minPhysicalArmDegrees < 0 || maxPhysicalArmDegrees < 0 || minSimDegrees < 0 || maxSimDegrees < 0) {
+            System.out.println("ERROR: Degrees must be non-negative");
+        }
+        if (minPhysicalArmDegrees >= 360.0 || maxPhysicalArmDegrees >= 360.0 || minSimDegrees >= 360.0 || maxSimDegrees >= 360.0) {
+            System.out.println("ERROR: Degrees must be less than 360");
+        }
+        if (minPhysicalArmDegrees >= maxPhysicalArmDegrees) {
+            System.out.println("ERROR: m_minPhysicalArmDegrees must be less than m_maxPhysicalArmDegrees");
+        }
+        if (minSimDegrees >= maxSimDegrees) {
+            System.out.println("ERROR: m_minSimDegrees must be less than m_maxSimDegrees");
+        }
+        this.m_minPhysicalArmDegrees = minPhysicalArmDegrees - bufferDegrees;
+        this.m_maxPhysicalArmDegrees = maxPhysicalArmDegrees + bufferDegrees;
+        this.m_minSimDegrees = minSimDegrees - bufferDegrees;
+        this.m_maxSimDegrees = maxSimDegrees + bufferDegrees;
+        this.m_inverted = inverted;
+    }
+
+    public RangeConvert(
+        double minPhysicalArmDegrees,
+        double maxPhysicalArmDegrees,
+        double minSimDegrees,
+        double maxSimDegrees,
+        double bufferDegrees) {
+
+        this(minPhysicalArmDegrees, maxPhysicalArmDegrees, minSimDegrees, maxSimDegrees, bufferDegrees, false);
+    }
+
+    public double getMinPhysicalArmDegrees() {
+        return m_minPhysicalArmDegrees;
+    }
+
+    public double getMaxPhysicalArmDegrees() {
+        return m_maxPhysicalArmDegrees;
+    }
+
+    public double getMinSimDegrees() {
+        return m_minSimDegrees;
+    }
+
+    public double getMaxSimDegrees() {
+        return m_maxSimDegrees;
+    }
+
+    public double simToPhysical(double simDegrees) {
+        if (simDegrees < m_minSimDegrees || simDegrees > m_maxSimDegrees) {
+            System.out.println("ERROR: simDegrees is out of range");
+        }
+        
+        // converts from simulation degrees to physical arm degrees
+        double result = (simDegrees - m_minSimDegrees) / (m_maxSimDegrees - m_minSimDegrees)
+                * (m_maxPhysicalArmDegrees - m_minPhysicalArmDegrees) + m_minPhysicalArmDegrees;
+
+        if (m_inverted) {
+            result = m_maxPhysicalArmDegrees - result + m_minPhysicalArmDegrees;
+        }
+
+        return result;
+    }
+
+    public double physicalToSim(double physicalDegrees) {
+        if (physicalDegrees < m_minPhysicalArmDegrees || physicalDegrees > m_maxPhysicalArmDegrees) {
+            System.out.println("ERROR: armDegrees is out of range");
+        }
+
+        // converts from physical arm degrees to simulation degrees
+        double result = (physicalDegrees - m_minPhysicalArmDegrees) / (m_maxPhysicalArmDegrees - m_minPhysicalArmDegrees)
+                * (m_maxSimDegrees - m_minSimDegrees) + m_minSimDegrees;
+
+        if (m_inverted) {
+            result = m_maxSimDegrees - result + m_minSimDegrees;
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/frc/robot/util/RelativeEncoderSim.java
+++ b/src/main/java/frc/robot/util/RelativeEncoderSim.java
@@ -1,0 +1,37 @@
+package frc.robot.util;
+
+import com.revrobotics.RelativeEncoder;
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Rev robotics doesnt have a simulation class for RelativeEncoder. However,
+ * a common pattern in FRC is to only set the RelativeEncoder's current position
+ * by setting it on the RelativeEncoderSim object. This way, the simulation never
+ * directly touches the RelativeEncoder object, which is a bit cleaner.
+ */
+public class RelativeEncoderSim {
+    private RelativeEncoder m_relEncoder;
+
+    /**
+     * Constructor.
+     */
+    public RelativeEncoderSim(RelativeEncoder relEncoder) {
+        // This entire class should only be instantiated when we're under simulation.
+        // But just in-case someone tries to instantiate it otherwise, we do an extra check here.
+        if (RobotBase.isSimulation()) {
+            m_relEncoder = relEncoder;
+        }
+        else {
+            System.out.println("ERROR: RelativeEncoderSim should only be instantiated in simulation mode.");
+            m_relEncoder = null;
+        }
+    }
+
+    public double getPosition() {
+        return m_relEncoder.getPosition();
+    }
+
+    public void setPosition(double position) {
+        m_relEncoder.setPosition(position);
+    }
+}


### PR DESCRIPTION
Fix goUp button

Cleanup

Cleanup

Turn off competetive mode in this branch

Add IOArmSimInterface

Implement IOArmSim

Move arm logic into ArmSimulation

Move armsim logic into ArmSimulation

Cleanup

Cleanup

Part1 of cleaning up units

Accidentally checked-in simgui.json

Cleanup variable names to make units clearer

Fix arm jitter

Add comment

Separate physical arm degrees from sim arm degrees

Convert between two ranges

Part1 of passing in RangeConvert

Use new range to get min max values

Cleanup

Fix bug where defaultarm command was constantly setting PID setloop, even though its closed pid loop

Properly convert between physical degrees and sim degrees

Support invert angles

Fix how we update relative encoder in sim

Support initializing arm simulation absolute encoder to halfway up

Cleanup ArmIntakeSystem

Cleanup

Cleanup

Cleanup

Separate Mech2d display from simulation

Cleanup

Ad buffer degrees

Fix bug where we were printing an error incorrectly

Go back to previous method names

Undo unnecessary IntakeArmSystem fixes

Undo fix until we can test on actual robot

Remove unnecessary change to simgui

Undo changing competition mode

Add back file

Cleanup