### PR TITLE
Add Wheel Calibration, and CheckStyle for code formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ Temporary Items
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/RamenFormatting.xml
+!.vscode/RamenCheckstyle.xml
 
 ### Windows ###
 # Windows thumbnail cache files

--- a/.vscode/RamenCheckstyle.xml
+++ b/.vscode/RamenCheckstyle.xml
@@ -1,0 +1,444 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+
+    Authors: Max Vetrenko, Mauryan Kansara, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name="Checker">
+
+  <property name="charset" value="UTF-8"/>
+
+  <property name="severity" value="${org.checkstyle.google.severity}" default="warning"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/filefilters/index.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <module name="SuppressWarningsFilter"/>
+
+  <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+           default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- https://checkstyle.org/filters/suppresswithnearbytextfilter.html -->
+  <module name="SuppressWithNearbyTextFilter">
+    <property name="nearbyTextPattern"
+              value="CHECKSTYLE.SUPPRESS\: (\w+) for ([+-]\d+) lines"/>
+    <property name="checkPattern" value="$1"/>
+    <property name="lineRange" value="$2"/>
+  </module>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="100"/>
+    <property name="ignorePattern"
+             value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
+  </module>
+
+  <module name="TreeWalker">
+    <module name="OuterTypeFilename"/>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+      <property name="format"
+               value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+      <property name="message"
+               value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true"/>
+      <property name="allowByTailComment" value="true"/>
+      <property name="allowNonPrintableEscapes" value="true"/>
+    </module>
+    <module name="AvoidStarImport"/>
+    <module name="OneTopLevelClass"/>
+    <module name="NoLineWrap">
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+    </module>
+    <module name="NeedBraces">
+      <property name="tokens"
+               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="id" value="LeftCurlyEol"/>
+      <property name="tokens"
+                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CATCH,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="id" value="LeftCurlyNl"/>
+      <property name="option" value="nl"/>
+      <property name="tokens"
+                value="LITERAL_CASE, LITERAL_DEFAULT"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- LITERAL_CASE, LITERAL_DEFAULT are reused in SWITCH_RULE  -->
+      <property name="id" value="LeftCurlyNl"/>
+      <property name="query" value="//SWITCH_RULE/SLIST"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlySame"/>
+      <property name="tokens"
+               value="LITERAL_TRY, LITERAL_CATCH, LITERAL_ELSE,
+                    LITERAL_DO"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="option" value="alone"/>
+      <property name="tokens"
+               value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_FINALLY"/>
+    </module>
+    <module name="RightCurly">
+      <property name="option" value="alone_or_singleline"/>
+      <property name="tokens" value="LITERAL_IF"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
+                                     or preceding-sibling::*[last()][self::LCURLY]]"/>
+    </module>
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+               value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, DO_WHILE, ELLIPSIS,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA,
+                    LITERAL_YIELD, LITERAL_CASE, LITERAL_WHEN"/>
+    </module>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
+      <property name="allowEmptySwitchBlockStatements" value="true"/>
+      <property name="ignoreEnhancedForColon" value="false"/>
+      <property name="tokens"
+               value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT,
+                    TYPE_EXTENSION_AND, LITERAL_WHEN"/>
+      <message key="ws.notFollowed"
+              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
+               may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+      <message key="ws.notPreceded"
+              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="WhitespaceAround"/>
+      <property name="query" value="//*[self::LITERAL_IF or self::LITERAL_ELSE or self::STATIC_INIT
+                                 or self::LITERAL_TRY or self::LITERAL_CATCH]/SLIST[count(./*)=1]
+                                 | //*[self::STATIC_INIT or self::LITERAL_TRY or self::LITERAL_IF]
+                                 //*[self::RCURLY][parent::SLIST[count(./*)=1]]"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="\{[ ]+\}"/>
+      <property name="message" value="Empty blocks should have no spaces. Empty blocks
+                                   may only be represented as '{}' when not part of a
+                                   multi-block statement (4.1.3)"/>
+    </module>
+    <module name="OneStatementPerLine"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="FallThrough"/>
+    <module name="UpperEll"/>
+    <module name="ModifierOrder"/>
+    <module name="EmptyLineSeparator">
+      <property name="tokens"
+               value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapDot"/>
+      <property name="tokens" value="DOT"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapComma"/>
+      <property name="tokens" value="COMMA"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/259 -->
+      <property name="id" value="SeparatorWrapEllipsis"/>
+      <property name="tokens" value="ELLIPSIS"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/258 -->
+      <property name="id" value="SeparatorWrapArrayDeclarator"/>
+      <property name="tokens" value="ARRAY_DECLARATOR"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapMethodRef"/>
+      <property name="tokens" value="METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+      <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="TypeName">
+      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF"/>
+      <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^(m_)[a-z][a-zA-Z0-9]*$"/>
+      <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LocalVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="PatternVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordComponentName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Record component name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Record type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="NoFinalizer"/>
+    <module name="GenericWhitespace">
+      <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+      <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+      <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="braceAdjustment" value="4"/>
+      <property name="caseIndent" value="4"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="arrayInitIndent" value="4"/>
+    </module>
+    <!-- Suppression for block code until we find a way to detect them properly
+         until https://github.com/checkstyle/checkstyle/issues/15769 -->
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="Indentation"/>
+      <property name="query" value="//SLIST[not(parent::CASE_GROUP)]/SLIST
+                                   | //SLIST[not(parent::CASE_GROUP)]/SLIST/RCURLY"/>
+    </module>
+    <module name="AbbreviationAsWordInName">
+      <property name="ignoreFinal" value="false"/>
+      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
+                    RECORD_COMPONENT_DEF"/>
+    </module>
+    <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+    <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="ConstructorsDeclarationGrouping"/>
+    <module name="VariableDeclarationUsageDistance"/>
+    <module name="CustomImportOrder">
+      <property name="sortImportsInGroupAlphabetically" value="true"/>
+      <property name="separateLineBetweenGroups" value="true"/>
+      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+      <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
+    </module>
+    <module name="MethodParamPad">
+      <property name="tokens"
+               value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF, CTOR_CALL,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF, RECORD_PATTERN_DEF"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens"
+               value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+    <module name="ParenPad">
+      <property name="tokens"
+               value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF, RECORD_PATTERN_DEF"/>
+    </module>
+    <module name="OperatorWrap">
+      <property name="option" value="NL"/>
+      <property name="tokens"
+               value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
+                    TYPE_EXTENSION_AND "/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationMostCases"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                      RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationVariables"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="allowSamelineMultipleAnnotations" value="true"/>
+    </module>
+    <module name="NonEmptyAtclauseDescription"/>
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocTagContinuationIndentation"/>
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments"
+               value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+    </module>
+    <module name="JavadocParagraph">
+      <property name="allowNewlineParagraph" value="false"/>
+    </module>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+    </module>
+    <module name="JavadocMethod">
+      <property name="accessModifiers" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="protected"/>
+      <property name="allowMissingPropertyJavadoc" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MissingJavadocMethod"/>
+      <property name="query" value="//*[self::METHOD_DEF or self::CTOR_DEF
+                                 or self::ANNOTATION_FIELD_DEF or self::COMPACT_CTOR_DEF]
+                                 [ancestor::*[self::INTERFACE_DEF or self::CLASS_DEF
+                                 or self::RECORD_DEF or self::ENUM_DEF]
+                                 [not(./MODIFIERS/LITERAL_PUBLIC)]]"/>
+    </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+      <property name="excludeScope" value="nothing"/>
+    </module>
+    <module name="MethodName">
+      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+      <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MethodName"/>
+      <property name="query" value="//METHOD_DEF[
+                                     ./MODIFIERS/ANNOTATION//IDENT[contains(@text, 'Test')]
+                                   ]/IDENT"/>
+      <property name="message" value="'[a-z][a-z0-9][a-zA-Z0-9]*(?:_[a-z][a-z0-9][a-zA-Z0-9]*)*'"/>
+    </module>
+    <module name="SingleLineJavadoc"/>
+    <module name="EmptyCatchBlock">
+      <property name="exceptionVariableName" value="expected"/>
+    </module>
+    <module name="CommentsIndentation">
+      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+    </module>
+    <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+             default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+    <module name="SuppressWarningsHolder" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
+      <property name="checkFormat" value="$1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>
+      <!-- $1 refers to the first match group in the regex defined in commentFormat -->
+      <property name="checkFormat" value="$1"/>
+      <!-- The check is suppressed in the next line of code after the comment -->
+      <property name="influenceFormat" value="1"/>
+    </module>
+  </module>
+</module>

--- a/.vscode/RamenFormatting.xml
+++ b/.vscode/RamenFormatting.xml
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="23">
+    <profile kind="CodeFormatterProfile" name="RamenRobotics" version="23">
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_before_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_switch_case_expressions" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_logical_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_abstract_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_enum_constant" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_permitted_types" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression_chain" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_annotations" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assertion_message_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_bitwise_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_not_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_permitted_types_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_record_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_bitwise_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_tag_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_constructor" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_string_concatenation" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_record_components" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_additive_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_record_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_switch_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_arrow" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_additive_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_constructor" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_relational_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_selector_in_method_invocation_on_expression_first_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_switch_case_with_arrow_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_colon" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_after_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_between_different_tags" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_shift_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_record_components" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_switch_case_with_arrow" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_constructor_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assertion_message" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_record_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_relational_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_logical_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_statement_group_in_switch" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_permitted_types" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="tab"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+    </profile>
+</profiles>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,5 +57,8 @@
     "edu.wpi.first.math.**.proto.*",
     "edu.wpi.first.math.**.struct.*",
   ],
-  "editor.formatOnSave": false
+  "editor.formatOnSave": false,
+  "java.format.settings.url": ".vscode/RamenFormatting.xml",
+  "java.checkstyle.configuration": "${workspaceFolder}/.vscode/RamenCheckstyle.xml",
+  "java.checkstyle.version": "10.23.0"
 }

--- a/src/main/deploy/nori/modules/backleft.json
+++ b/src/main/deploy/nori/modules/backleft.json
@@ -18,7 +18,7 @@
     "drive": false,
     "angle": false
   },
-  "absoluteEncoderOffset": 300,
+  "absoluteEncoderOffset": -60.0,
   "location": {
     "front": -10.75,
     "left": 10.75

--- a/src/main/deploy/nori/modules/frontright.json
+++ b/src/main/deploy/nori/modules/frontright.json
@@ -18,7 +18,7 @@
     "drive": true,
     "angle": false
   },
-  "absoluteEncoderOffset": -245.48,
+  "absoluteEncoderOffset": 114.52,
   "location": {
     "front": 10.75,
     "left": -10.75

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -48,6 +48,7 @@ import frc.robot.sim.simvision.VisionSystemInterface;
 import frc.robot.sim.simvision.VisionSystemSim;
 import frc.robot.util.AutoLogic;
 import frc.robot.vision.VisionSystem;
+import frc.robot.wheelcalibration.CalibrationOrchestrator;
 import frc.robot.logging.TriviaLogger;
 
 import java.io.File;
@@ -96,6 +97,8 @@ public class SwerveSubsystem extends SubsystemBase
 
   private boolean m_isPathfinderWarmedUp = false;
   private boolean m_hasWarnedOnce = false;
+
+  private CalibrationOrchestrator m_calibrationOrch = null;
 
   //
   // Simulated Vision
@@ -189,6 +192,17 @@ public class SwerveSubsystem extends SubsystemBase
       tab.add("Robot Position on Field", m_field);
       tab.add("Target Position on Field", m_targetField);
       tab.addBoolean("Path Planner Ready", () -> m_isPathfinderWarmedUp);
+
+      // Add buttons to help callibrate wheel angles
+      m_calibrationOrch = new CalibrationOrchestrator(swerveDrive);
+      Command takeReadingCmd = new InstantCommand(() -> m_calibrationOrch.takeReading());
+      tab.add("Take Wheel Reading", takeReadingCmd).withWidget("Command");
+
+      Command showReportCmd = new InstantCommand(() -> m_calibrationOrch.showReport());
+      tab.add("Show Report", showReportCmd).withWidget("Command");
+
+      Command resetReadingsCmd = new InstantCommand(() -> m_calibrationOrch.resetReadings());
+      tab.add("Reset Readings", resetReadingsCmd).withWidget("Command");
     }
 
     initLogging();

--- a/src/main/java/frc/robot/wheelcalibration/AngleHelpers.java
+++ b/src/main/java/frc/robot/wheelcalibration/AngleHelpers.java
@@ -1,0 +1,148 @@
+package frc.robot.wheelcalibration;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.geometry.Rotation2d;
+
+/**
+ * A utility class that provides helper methods for angle calculations,
+ * including distance between angles, normalization, and polarity checks.
+ * Note that a wheel can be rotated 180 degrees, and it's still pointing in the same direction.
+ * We refer to a calculation as 'ignoring polarity' when we ignore the ABSOLUTE direction
+ * of the wheel.
+ */
+public final class AngleHelpers {
+    private static final double maxDelta = 0.0001;
+    private static final double kMaxDegreesWhenNear = 8.0;
+
+    // Private constructor to prevent instantiation
+    private AngleHelpers() {
+        throw new UnsupportedOperationException(
+            "This is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Calculates the distance between two angles in degrees.
+     *
+     * @param angle1 The first angle to compare.
+     * @param angle2 The second angle to compare.
+     * @return The distance between the two angles in degrees.
+     */
+    public static double distanceBetweenAngles(Rotation2d angle1, Rotation2d angle2) {
+        Rotation2d constrainedAngle1 = normalizeAngle(angle1, -180, 180);
+        Rotation2d constrainedAngle2 = normalizeAngle(angle2, -180, 180);
+
+        return distanceBetweenAnglesHelper(constrainedAngle1, constrainedAngle2, 180.0);
+    }
+
+    /**
+     * Calculates the distance between two angles, ignoring their polarity.  (i.e. a wheel
+     * can be rotated 180 degrees, and its still pointing in the same direction).
+     *
+     * @param angle1 The first angle to compare.
+     * @param angle2 The second angle to compare.
+     * @return The distance between the two angles, ignoring polarity.
+     */
+    public static double distanceBetweenAnglesIgnoringPolarity(
+        Rotation2d angle1,
+        Rotation2d angle2) {
+
+        Rotation2d constrainedAngle1 = normalizeAngle(angle1, -90, 90);
+        Rotation2d constrainedAngle2 = normalizeAngle(angle2, -90, 90);
+
+        return distanceBetweenAnglesHelper(constrainedAngle1, constrainedAngle2, 90.0);
+    }
+
+    /**
+     * Checks if two angles are near each other within a specified threshold.
+     *
+     * @param angle1 The first angle to compare.
+     * @param angle2 The second angle to compare.
+     * @return True if the angles are near each other; otherwise, false.
+     */
+    public static boolean isAngleNear(Rotation2d angle1, Rotation2d angle2) {
+        double distance = distanceBetweenAngles(angle1, angle2);
+        return distance <= kMaxDegreesWhenNear + maxDelta;
+    }
+
+    /**
+     * Checks if two angles are near each other, ignoring polarity.
+     * A wheel can be rotated 180 degrees, and its still pointing in the same direction. This
+     * method ignores the wheel DIRECTION, and only checks the angle.
+     *
+     * @param angle1 The first angle to compare.
+     * @param angle2 The second angle to compare.
+     * @return True if the angles are near each other, ignoring polarity; otherwise, false.
+     */
+    public static boolean isAngleNearIgnoringPolarity(Rotation2d angle1, Rotation2d angle2) {
+        double result = distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        return result <= kMaxDegreesWhenNear + maxDelta;
+    }
+
+    // Given angleA and a reference angle, return either angleA or angleA + 180 degrees,
+    // whichever is closer to the reference angle.
+    /**
+     * Returns the angle (either the given angle or the given angle plus 180 degrees)
+     * that is closest to the reference angle.
+     *
+     * @param angle The angle to compare.
+     * @param referenceAngle The reference angle to compare against.
+     * @return The closest angle to the reference angle.
+     */
+    public static Rotation2d getClosestAngleToReference(
+        Rotation2d angle,
+        Rotation2d referenceAngle) {
+
+        // Make sure the angles are in their proper ranges
+        angle = normalizeAngle(angle, -90, 90);
+        referenceAngle = normalizeAngle(referenceAngle, -180, 180);
+        Rotation2d angleRotated = normalizeAngle(
+            Rotation2d.fromDegrees(angle.getDegrees() + 180.0),
+            -180,
+            180);
+
+        double distance = distanceBetweenAngles(angle, referenceAngle);
+        double distanceRotated = distanceBetweenAngles(angleRotated, referenceAngle);
+
+        if (distance <= distanceRotated) {
+            return angle;
+        }
+        else {
+            return angleRotated;
+        }
+    }
+
+    /**
+     * Normalizes the given angle to be within the specified bounds.
+     *
+     * @param angle The angle to normalize.
+     * @param lowerBound The lower bound of the range.
+     * @param upperBound The upper bound of the range.
+     * @return A Rotation2d object representing the normalized angle.
+     */
+    public static Rotation2d normalizeAngle(
+        Rotation2d angle,
+        double lowerBound,
+        double upperBound) {
+
+        double normalizedDegrees = MathUtil.inputModulus(
+            angle.getDegrees(),
+            lowerBound,
+            upperBound);
+        return Rotation2d.fromDegrees(normalizedDegrees);
+    }
+
+    // Returns the distance between two angles in degrees.
+    private static double distanceBetweenAnglesHelper(
+        Rotation2d angle1,
+        Rotation2d angle2,
+        double maxPositiveDegrees) {
+        double angle1Degrees = angle1.getDegrees();
+        double angle2Degrees = angle2.getDegrees();
+
+        return Math.abs(
+            MathUtil.inputModulus(
+                angle1Degrees - angle2Degrees,
+                -1.0 * maxPositiveDegrees,
+                maxPositiveDegrees));
+    }
+}

--- a/src/main/java/frc/robot/wheelcalibration/CalibrationOrchestrator.java
+++ b/src/main/java/frc/robot/wheelcalibration/CalibrationOrchestrator.java
@@ -1,0 +1,138 @@
+package frc.robot.wheelcalibration;
+
+import swervelib.SwerveDrive;
+import swervelib.SwerveModule;
+
+public class CalibrationOrchestrator {
+    private final int m_numWheels;
+    private final WheelCalibration[] m_wheelCalibrations;
+    private int m_numReadings;
+    private int m_numFailedReadings;
+
+    // Constructor
+    public CalibrationOrchestrator(SwerveDrive swerveDrive) {
+        m_wheelCalibrations = createWheelCalibrations(swerveDrive);
+        m_numWheels = m_wheelCalibrations.length;
+    }
+
+    private void resetReadingsHelper() {
+        m_numReadings = 0;
+        m_numFailedReadings = 0;
+
+        for (int i = 0; i < m_numWheels; i++) {
+            m_wheelCalibrations[i].resetReadings();
+        }
+    }
+
+    private static WheelCalibration[] createWheelCalibrations(SwerveDrive swerveDrive) {
+        SwerveModule[] swerveModules = swerveDrive.getModules();
+
+        int numWheels = swerveModules.length;
+        WheelCalibration[] wheelCalibrations = new WheelCalibration[numWheels];
+
+        for (int i = 0; i < numWheels; i++) {
+            wheelCalibrations[i] = new WheelCalibration(swerveModules[i]);
+        }
+
+        return wheelCalibrations;
+    }
+
+    private boolean areAllWheelsStraight() {
+        boolean areAllWheelsStraight = true;
+        for (int i = 0; i < m_numWheels; i++) {
+            WheelCalibration wheel = m_wheelCalibrations[i];
+            if (!wheel.isWheelStraight()) {
+                areAllWheelsStraight = false;
+                break;
+            }
+        }
+
+        return areAllWheelsStraight;
+    }
+
+    private boolean areAllWheelOffsetConfigsInRange() {
+        boolean areAllWheelOffsetConfigsInRange = true;
+        for (int i = 0; i < m_numWheels; i++) {
+            WheelCalibration wheel = m_wheelCalibrations[i];
+            if (!wheel.isConfigOffsetInGoodRange()) {
+                areAllWheelOffsetConfigsInRange = false;
+                break;
+            }
+        }
+
+        return areAllWheelOffsetConfigsInRange;
+    }
+
+    /**
+     * Takes a reading for all wheels if their offset configurations are in range
+     * and all wheels are straight.
+     */
+    public void takeReading() {
+        if (!areAllWheelOffsetConfigsInRange()) {
+            m_numFailedReadings++;
+            return;
+        }
+
+        if (!areAllWheelsStraight()) {
+            System.out.println(
+                "ERROR: Expected takeReading() to only be called when all wheels are straight.");
+            m_numFailedReadings++;
+            return;
+        }
+
+        boolean gotReading = true;
+        for (int i = 0; i < m_numWheels; i++) {
+            WheelCalibration wheel = m_wheelCalibrations[i];
+            if (!wheel.takeReading()) {
+                System.out
+                    .println("ERROR: Reading should have succeeded since all wheels straight.");
+                gotReading = false;
+            }
+        }
+        if (gotReading) {
+            m_numReadings++;
+        }
+        else {
+            m_numFailedReadings++;
+        }
+
+        System.out.println(
+            "Num readings: " + m_numReadings + " num failed readings: " + m_numFailedReadings);
+    }
+
+    /**
+     * Displays a report of the calibration results, including average angles and changes
+     * in degrees for each wheel.
+     */
+    public void showReport() {
+        if (m_numReadings == 0) {
+            System.out.println("No readings taken yet!");
+            return;
+        }
+
+        System.out.println("-------------------------");
+        System.out.println("Calibration Report:");
+        System.out.println("--------------------------");
+
+        for (int i = 0; i < m_numWheels; i++) {
+            WheelCalibration wheel = m_wheelCalibrations[i];
+            System.out.println(
+                wheel.getModuleName()
+                    + " ("
+                    + i
+                    + ") average angle: "
+                    + Math.round(wheel.getAverageReading() * 10000.0) / 10000.0
+                    + " (change degrees: "
+                    + Math.round(wheel.getChangeInDegrees() * 100.0) / 100.0
+                    + ")");
+        }
+    }
+
+    /**
+     * Resets the readings for all wheels by clearing the number of readings and failed readings.
+     */
+    public void resetReadings() {
+        resetReadingsHelper();
+        System.out.println("Reset readings for all wheels.");
+    }
+}

--- a/src/main/java/frc/robot/wheelcalibration/WheelCalibration.java
+++ b/src/main/java/frc/robot/wheelcalibration/WheelCalibration.java
@@ -1,0 +1,179 @@
+package frc.robot.wheelcalibration;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import swervelib.SwerveModule;
+
+/**
+ * The WheelCalibration class is responsible for calibrating the swerve module's wheel angles.
+ * It provides methods to take readings, check alignment, and calculate angle offsets.
+ */
+public class WheelCalibration {
+    private SwerveModule m_swerveModule;
+    private double m_runningTotalAngles;
+    private int m_numReadings;
+
+    /**
+     * Constructor for WheelCalibration.
+     *
+     * @param swerveModule The swerve module to be calibrated.
+     */
+    public WheelCalibration(SwerveModule swerveModule) {
+        m_swerveModule = swerveModule;
+        resetReadingsHelper();
+    }
+
+    /**
+     * Takes a reading of the current wheel angle if the wheel is straight.
+     * If the wheel is not straight, an error message is printed and the method returns false.
+     *
+     * @return true if the reading was successfully taken, false otherwise.
+     */
+    public boolean takeReading() {
+        if (!isWheelStraight()) {
+            System.out
+                .println("ERROR: Expected takeReading() to only be called when wheel is straight.");
+            return false;
+        }
+
+        // After we get the wheel reading, we may flip the polarity so that the reading
+        // is close to configured offset. This is so that we recommend an offset thats
+        // in the same vacinity as the current configured offset.
+        Rotation2d currentAngle = readCurrentAbsoluteAngleWithOffset();
+        currentAngle = AngleHelpers.getClosestAngleToReference(
+            currentAngle,
+            Rotation2d.fromDegrees(getConfigationOffsetDegrees()));
+
+        recordReading(currentAngle);
+
+        return true;
+    }
+
+    // Return false if the wheel is turned too far from straight.
+    /**
+     * Checks if the wheel is straight by comparing the current angle with the
+     * configured offset angle.
+     *
+     * @return true if the wheel is straight, false otherwise.
+     */
+    public boolean isWheelStraight() {
+        Rotation2d currentAngleNoPolarity = AngleHelpers.normalizeAngle(
+            readCurrentAbsoluteAngleWithOffset(),
+            -90,
+            90);
+
+        Rotation2d offsetAngleNoPolarity = AngleHelpers.normalizeAngle(
+            Rotation2d.fromDegrees(getConfigationOffsetDegrees()),
+            -90,
+            90);
+
+        return AngleHelpers.isAngleNear(currentAngleNoPolarity, offsetAngleNoPolarity);
+    }
+
+    /**
+     * Checks if the configuration offset is within the valid range (-180, 180).
+     * If not, it prints an error message with a recommended offset value.
+     *
+     * @return true if the configuration offset is in the valid range, false otherwise.
+     */
+    public boolean isConfigOffsetInGoodRange() {
+        double offsetDegrees = getConfigationOffsetDegrees();
+        if (offsetDegrees <= -180 || offsetDegrees >= 180) {
+            double recommendedOffset = Math.round(
+                AngleHelpers.normalizeAngle(Rotation2d.fromDegrees(offsetDegrees), -180, 180)
+                    .getDegrees() * 100000.0)
+                / 100000.0;
+            System.out.println(
+                "ERROR: "
+                    + getModuleName()
+                    + ": Config offset is not in correct range (-180, 180): "
+                    + offsetDegrees
+                    + " (instead use "
+                    + recommendedOffset
+                    + " degrees");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void recordReading(Rotation2d angle) {
+        m_runningTotalAngles += angle.getDegrees();
+        m_numReadings++;
+
+        System.out.println(
+            "Reading: "
+                + getModuleName()
+                + " angle: "
+                + Math.round(angle.getDegrees() * 10000.0) / 10000.0);
+    }
+
+    private void resetReadingsHelper() {
+        m_runningTotalAngles = 0.0;
+        m_numReadings = 0;
+    }
+
+    /**
+     * Resets the readings by clearing the running total and the number of readings.
+     */
+    public void resetReadings() {
+        resetReadingsHelper();
+    }
+
+    /**
+     * Calculates and returns the average of the recorded wheel angle readings.
+     * If no readings have been taken, it prints an error message and returns -1.0.
+     *
+     * @return The average wheel angle reading, or -1.0 if no readings are available.
+     */
+    public double getAverageReading() {
+        if (m_numReadings == 0) {
+            System.out.println("ERROR: No readings taken yet.");
+            return -1.0;
+        }
+
+        return m_runningTotalAngles / m_numReadings;
+    }
+
+    // Returns an absolute value
+    /**
+     * Calculates the absolute change in degrees between the average reading and the
+     * configuration offset.  If no readings are available, it returns -1.0.
+     *
+     * @return The absolute change in degrees, or -1.0 if no readings are available.
+     */
+    public double getChangeInDegrees() {
+        double averageReading = getAverageReading();
+        if (averageReading == -1.0) {
+            return -1.0;
+        }
+
+        double offsetDegrees = getConfigationOffsetDegrees();
+        double changeInDegrees = Math.abs(averageReading - offsetDegrees);
+
+        return changeInDegrees;
+    }
+
+    public String getModuleName() {
+        return m_swerveModule.configuration.name;
+    }
+
+    // Absolute position, constrained to -180 to 180 degrees.
+    private Rotation2d readCurrentRawAbsoluteAngle() {
+        SwerveModuleState moduleState = m_swerveModule.getState();
+        Rotation2d encoderAngle = moduleState.angle;
+
+        return AngleHelpers.normalizeAngle(encoderAngle, -180, 180);
+    }
+
+    // Constrained -180 to 180 degrees.
+    private Rotation2d readCurrentAbsoluteAngleWithOffset() {
+        double resultDegrees = readCurrentRawAbsoluteAngle().getDegrees()
+            + getConfigationOffsetDegrees();
+        return AngleHelpers.normalizeAngle(Rotation2d.fromDegrees(resultDegrees), -180, 180);
+    }
+
+    private double getConfigationOffsetDegrees() {
+        return m_swerveModule.configuration.angleOffset;
+    }
+}

--- a/src/test/java/frc/robot/wheelcalibration/AngleHelpersTest.java
+++ b/src/test/java/frc/robot/wheelcalibration/AngleHelpersTest.java
@@ -1,0 +1,698 @@
+package frc.robot.wheelcalibration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the AngleHelpers utility class.
+ * This class tests various angle-related helper methods to ensure correctness.
+ */
+public class AngleHelpersTest {
+    private static final double maxDelta = 0.0001; // Allowable delta for floating point comparisons
+
+    //
+    // Test normalizeAngle method
+    //
+
+    @Test
+    public void testNormalizeAngleWithinBounds() {
+        double angle = 5.0;
+
+        double expected = angle;
+        Rotation2d actual = AngleHelpers.normalizeAngle(Rotation2d.fromDegrees(angle), -180, 180);
+        assertEquals(expected, actual.getDegrees(), "The angle should be unchanged.");
+    }
+
+    @Test
+    public void testNormalizeAngleAtPositiveBoundary() {
+        double angle = 180.0;
+
+        double expected = 180.0;
+        Rotation2d actual = AngleHelpers.normalizeAngle(Rotation2d.fromDegrees(angle), -180, 180);
+        assertEquals(expected, actual.getDegrees(), "The angle should be unchanged.");
+    }
+
+    @Test
+    public void testNormalizeAngleAtNegativeBoundary() {
+        double angle = -180.0;
+
+        double expected = 180.0;
+        Rotation2d actual = AngleHelpers.normalizeAngle(Rotation2d.fromDegrees(angle), -180, 180);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            "Expected 180 given implementation of MathUtil.inputModulus.");
+    }
+
+    @Test
+    public void testNormalizeAngleAbovePositiveBoundary() {
+        double angle = 181.0;
+
+        double expected = -179.0;
+        Rotation2d actual = AngleHelpers.normalizeAngle(Rotation2d.fromDegrees(angle), -180, 180);
+        assertEquals(expected, actual.getDegrees(), "The angle should wrap around.");
+    }
+
+    @Test
+    public void testNormalizeAngleBelowNegativeBoundary() {
+        double angle = -181.0;
+
+        double expected = 179.0;
+        Rotation2d actual = AngleHelpers.normalizeAngle(Rotation2d.fromDegrees(angle), -180, 180);
+        assertEquals(expected, actual.getDegrees(), "The angle should wrap around.");
+    }
+
+    @Test
+    public void testNormalizeAngleLargeNegativeValue() {
+        double angle = -1000.0;
+
+        // -1000 mod 360 = -280, which is 80 degrees in the positive direction.
+        double expected = 80.0;
+        Rotation2d actual = AngleHelpers.normalizeAngle(Rotation2d.fromDegrees(angle), -180, 180);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "The angle should wrap around correctly.");
+    }
+
+    //
+    // Test distanceBetweenAngles method
+    //
+
+    @Test
+    public void testDistanceBetweenAnglesSimpleDifference() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(30.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(45.0);
+
+        double expected = 15.0;
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(expected, actual, maxDelta, "The distance should be 15 degrees.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIdenticalAngles() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(90.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(90.0);
+
+        double expected = 0.0;
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(expected, actual, "The distance should be 0 degrees for identical angles.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesOppositeAngles() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(0.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(180.0);
+
+        double expected = 180.0;
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(expected, actual, "The distance should be 180 degrees for opposite angles.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesAcrossBoundary() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(170.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-170.0);
+
+        double expected = 20.0; // The shortest path is 20 degrees, not 340 degrees
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            "The distance should account for wrapping around the circle.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesPositiveAndNegative() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(45.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-45.0);
+
+        double expected = 90.0;
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(expected, actual, "The distance should be 90 degrees.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesBothPositive() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(30.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(120.0);
+
+        double expected = 90.0;
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should be within the allowed delta.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesBothNegative() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(-30.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-120.0);
+
+        double expected = 90.0;
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should be within the allowed delta.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesBoundaryValues() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(-180.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(180.0);
+
+        double expected = 0.0; // These angles represent the same position
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(expected, actual, "The distance should be 0 for -180 and 180 degrees.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesExtremeValues() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(720.0); // Equivalent to 0 degrees
+        Rotation2d angle2 = Rotation2d.fromDegrees(-540.0); // Equivalent to 180 degrees
+
+        double expected = 180.0;
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(expected, actual, "The distance should handle extreme values correctly.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesNearBoundary() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(179.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-179.0);
+
+        double expected = 2.0; // The shortest path is 2 degrees around the boundary
+        double actual = AngleHelpers.distanceBetweenAngles(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            "The distance should find the shortest path around the circle.");
+    }
+
+    //
+    // Test isAngleNear
+    //
+
+    @Test
+    public void testIsAngleNearExactlyAtThreshold() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(0.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(8.0); // kMaxDegreesWhenNear is 8.0
+
+        boolean expected = true;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(expected, actual, "Angles exactly at threshold should be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearJustOverThreshold() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(0.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(8.1); // Just over kMaxDegreesWhenNear
+
+        boolean expected = false;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(expected, actual, "Angles just over threshold should not be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearJustUnderThreshold() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(0.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(7.9); // Just under kMaxDegreesWhenNear
+
+        boolean expected = true;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(expected, actual, "Angles just under threshold should be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearIdenticalAngles() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(45.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(45.0);
+
+        boolean expected = true;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(expected, actual, "Identical angles should be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearFarApart() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(0.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(90.0);
+
+        boolean expected = false;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(expected, actual, "Angles far apart should not be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearCrossingBoundary() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(178.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-178.0);
+
+        boolean expected = true;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            "Angles near but crossing the +/-180 boundary should be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearLargeValues() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(365.0); // Equivalent to 5 degrees
+        Rotation2d angle2 = Rotation2d.fromDegrees(10.0);
+
+        boolean expected = true;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            "Large angle values that are near when normalized should be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearNegativeValues() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(-50.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-55.0);
+
+        boolean expected = true;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(expected, actual, "Negative angles that are near should be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNear360DegreesApart() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(720.0); // Equivalent to 0 degrees
+        Rotation2d angle2 = Rotation2d.fromDegrees(0.0);
+
+        boolean expected = true;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            "Angles 360 degrees apart should be considered near as they're the same position.");
+    }
+
+    @Test
+    public void testIsAngleNearOppositeDirections() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(0.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(180.0);
+
+        boolean expected = false;
+        boolean actual = AngleHelpers.isAngleNear(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            "Angles in opposite directions should not be considered near.");
+    }
+
+    //
+    // Test distanceBetweenAnglesIgnoringPolarity
+    //
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolaritySameAngle() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(45.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(45.0);
+
+        double expected = 0.0;
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(expected, actual, maxDelta, "The distance should be 0 for identical angles.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolarity180DegreesApart() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(45.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(225.0); // 45 + 180
+
+        double expected = 0.0;
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should be 0 for angles flipped 180 degrees.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolarity90DegreesApart() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(0.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(90.0);
+
+        double expected = 90.0;
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should be 90 degrees for perpendicular angles.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolarityMoreThan90DegreesApart() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(0.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(135.0);
+
+        double expected = 45.0; // When ignoring polarity, 135° becomes equivalent to -45°
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should account for wheel flipping when >90 degrees apart.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolarityWrappingAround() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(170.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-170.0);
+
+        double expected = 20.0; // When considering flipping, these are 20 degrees apart
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should correctly handle angles that wrap around.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolarityAtBoundaries() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(90.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-90.0);
+
+        double expected = 0.0; // These are effectively the same direction when ignoring polarity
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should be 0 for angles at opposite boundaries.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolarityNearBoundaries() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(85.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-85.0);
+
+        double expected = 10.0; // When accounting for flipping, these are 10 degrees apart
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should correctly handle angles near boundaries.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolarityExtremeValues() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(450.0); // Equivalent to 90 degrees
+        Rotation2d angle2 = Rotation2d.fromDegrees(-270.0); // Equivalent to -270 degrees
+
+        double expected = 0.0; // These are effectively the same direction when ignoring polarity
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should correctly handle extreme angle values.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolaritySmallDifference() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(5.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(10.0);
+
+        double expected = 5.0;
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            maxDelta,
+            "The distance should be correct for small angle differences.");
+    }
+
+    @Test
+    public void testDistanceBetweenAnglesIgnoringPolarityEdgeCase() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(0.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(180.0);
+
+        double expected = 0.0; // These are effectively the same direction when ignoring polarity
+        double actual = AngleHelpers.distanceBetweenAnglesIgnoringPolarity(angle1, angle2);
+        assertEquals(expected, actual, maxDelta, "The distance should be 0 for opposite angles.");
+    }
+
+    //
+    // Test isAngleNearIgnoringPolarity
+    //
+
+    @Test
+    public void testIsAngleNearIgnoringPolarityWheelFlipped() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(85);
+        Rotation2d angle2 = Rotation2d.fromDegrees(85.0 + 8.0 + 180.0);
+
+        boolean expected = true; // These are effectively the same direction when ignoring polarity
+        boolean actual = AngleHelpers.isAngleNearIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            "The angles should be considered near when ignoring polarity.");
+    }
+
+    @Test
+    public void testIsAngleNearIgnoringPolarityTooFar() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(85);
+        Rotation2d angle2 = Rotation2d.fromDegrees(85.0 + 8.01 + 180.0);
+
+        boolean expected = false;
+        boolean actual = AngleHelpers.isAngleNearIgnoringPolarity(angle1, angle2);
+        assertEquals(expected, actual, "Just a hair further than the threshold.");
+    }
+
+    @Test
+    public void testIsAngleNearIgnoringPolarityNegativeWheelFlipped() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(-85);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-85.0 - 8.0 + 180.0);
+
+        boolean expected = true; // These are effectively the same direction when ignoring polarity
+        boolean actual = AngleHelpers.isAngleNearIgnoringPolarity(angle1, angle2);
+        assertEquals(
+            expected,
+            actual,
+            "The angles should be considered near when ignoring polarity.");
+    }
+
+    @Test
+    public void testIsAngleNearIgnoringPolarityNegativeTooFar() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(-85);
+        Rotation2d angle2 = Rotation2d.fromDegrees(-85.0 - 8.01 + 180.0);
+
+        boolean expected = false;
+        boolean actual = AngleHelpers.isAngleNearIgnoringPolarity(angle1, angle2);
+        assertEquals(expected, actual, "Just a hair further than the threshold.");
+    }
+
+    @Test
+    public void testIsAngleNearIgnoringPolarityBasicCase() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(30.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(45.0);
+
+        boolean expected = false;
+        boolean actual = AngleHelpers.isAngleNearIgnoringPolarity(angle1, angle2);
+        assertEquals(expected, actual, "The angles should not be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearIgnoringPolarityWithinThreshold() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(30.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(38.0);
+
+        boolean expected = true;
+        boolean actual = AngleHelpers.isAngleNearIgnoringPolarity(angle1, angle2);
+        assertEquals(expected, actual, "The angles should be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearIgnoringPolarityLargeValues() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(400.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(400.0);
+
+        boolean expected = true;
+        boolean actual = AngleHelpers.isAngleNearIgnoringPolarity(angle1, angle2);
+        assertEquals(expected, actual, "The angles should be considered near.");
+    }
+
+    @Test
+    public void testIsAngleNearIgnoringPolarityOutsideThreshold() {
+        Rotation2d angle1 = Rotation2d.fromDegrees(400.0);
+        Rotation2d angle2 = Rotation2d.fromDegrees(410.0);
+
+        boolean expected = false;
+        boolean actual = AngleHelpers.isAngleNearIgnoringPolarity(angle1, angle2);
+        assertEquals(expected, actual, "The angles should not be considered near.");
+    }
+
+    //
+    // Test getClosestAngleToReference
+    //
+
+    @Test
+    public void testGetClosestAngleToReferenceOriginalCloser() {
+        Rotation2d angleA = Rotation2d.fromDegrees(30.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(45.0);
+
+        double expected = 30.0;
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "Original angle should be closer to reference.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReferenceRotatedCloser() {
+        Rotation2d angleA = Rotation2d.fromDegrees(30.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(240.0);
+
+        double expected = -150.0; // 30+180=210, constrained to -180 to 180 is -150
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "Rotated angle should be closer to reference.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReferenceBoundaryCase() {
+        Rotation2d angleA = Rotation2d.fromDegrees(90.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(100.0);
+
+        double expected = 90.0;
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "Angle at boundary should return correct result.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReferenceNegativeBoundaryCase() {
+        Rotation2d angleA = Rotation2d.fromDegrees(-90.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(-100.0);
+
+        double expected = -90.0;
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "Negative angle at boundary should return correct result.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReferenceIdenticalAngles() {
+        Rotation2d angleA = Rotation2d.fromDegrees(45.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(45.0);
+
+        double expected = 45.0;
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "Identical angles should return the original angle.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReferenceOppositeSides() {
+        Rotation2d angleA = Rotation2d.fromDegrees(0.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(179.0);
+
+        double expected = 180.0;
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "Should return original angle when reference is on opposite side but closer.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReferenceLargeValues() {
+        Rotation2d angleA = Rotation2d.fromDegrees(400.0); // Equivalent to 40 degrees
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(210.0); // Equivalent to -150 degrees
+
+        double expected = -140.0; // 40+180=220, constrained to -180 to 180 is -140
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "Should handle large angle values correctly.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReferenceNegativeValues() {
+        Rotation2d angleA = Rotation2d.fromDegrees(-30.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(-45.0);
+
+        double expected = -30.0;
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "Should handle negative angles correctly.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReferenceCrossingBoundary() {
+        Rotation2d angleA = Rotation2d.fromDegrees(170.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(-170.0);
+
+        double expected = 170.0; // -10+180=170, constrained to -180 to 180 is 170
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "Should handle angles that cross boundaries correctly.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReferenceExactly90DegreesApart() {
+        Rotation2d angleA = Rotation2d.fromDegrees(0.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(90.0);
+
+        double expected = 0.0; // Original angle is closer to reference than rotated (180)
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "When angles are exactly 90 degrees apart, should return original.");
+    }
+
+    @Test
+    public void testGetClosestAngleToReference91DegreesApart() {
+        Rotation2d angleA = Rotation2d.fromDegrees(0.0);
+        Rotation2d referenceAngle = Rotation2d.fromDegrees(91.0);
+
+        double expected = 180.0;
+        Rotation2d actual = AngleHelpers.getClosestAngleToReference(angleA, referenceAngle);
+        assertEquals(
+            expected,
+            actual.getDegrees(),
+            maxDelta,
+            "When angles are 91 degrees apart, should return rotated.");
+    }
+}


### PR DESCRIPTION
Cleanup

Cleanup

Add empty unittests

Make portion of WheelCalibration static so I can test

Add some test cases

Fix unit tests

Fix a unit test

Cleanup

Add more unit tests

Cleanup

Add more unit tests

Refactor

Add calibration orchestrator

Check if wheels straight

Add resetReadings command

Add reset readings

Add getClosestAngleToReference

recording reading works

Fix the measured angle to be between -360 and 360, which is 720 degrees

Show report

Print numbers rounded

Refactors angle normalization

Replaces multiple constrain angle methods with a single, generalized `normalizeAngle` method.

This change improves code readability and maintainability by consolidating angle normalization logic into one function.

Put tests in correct directory to be discovered

Cleanup directories

Do not take readings if json offsets out of range

Get rid of the bad code that allowed 720 degrees

Add Eclipse formatter

Enable Eclipse Format Document

Only indent one tab stop on continuation

Format document

Format test document too

Add Checkstyle

Change default indentation to 4

Class variables should be prepended with m_

Linting

Cleanup

Linting

Cleanup

Cleanup naming

Else is on newline in checkstyle

Linting

Make sure wheel offsets are in range (-180,180)