### PR TITLE
Show arm as red when out of range instead of printing to the console

### DIFF
--- a/src/main/java/frc/robot/ramenlib/sim/armsimulation/ArmDisplay.java
+++ b/src/main/java/frc/robot/ramenlib/sim/armsimulation/ArmDisplay.java
@@ -1,5 +1,6 @@
 package frc.robot.ramenlib.sim.armsimulation;
 
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
@@ -13,6 +14,9 @@ import frc.robot.ramenlib.sim.simutil.RangeConvert;
  * in the simulation using WPILib's Mechanism2d.
  */
 public class ArmDisplay {
+    private static final Color8Bit m_defaultArmColor = new Color8Bit(Color.kYellow);
+    private static final Color8Bit m_brokenArmColor = new Color8Bit(Color.kRed);
+    private static final double m_epsilonBrokenDegrees = 2.0;
     private RangeConvert m_rangesPhysicalAndSim;
     private Mechanism2d m_mech2d;
     private MechanismLigament2d m_armLigament;
@@ -40,7 +44,23 @@ public class ArmDisplay {
     public void setAngle(double physicalArmRads) {
         double physicalArmDegrees = Units.radiansToDegrees(physicalArmRads);
         double simArmDegrees = m_rangesPhysicalAndSim.physicalToSim(physicalArmDegrees);
+
+        Color8Bit armColor = isBroken(simArmDegrees) ? m_brokenArmColor : m_defaultArmColor;
+
+        // We will only DISPLAY the arm as being between [min,max]
+        simArmDegrees = MathUtil.clamp(
+            simArmDegrees,
+            m_rangesPhysicalAndSim.getMinSimDegrees(),
+            m_rangesPhysicalAndSim.getMaxSimDegrees());
+
         m_armLigament.setAngle(simArmDegrees);
+        m_armLigament.setColor(armColor);
+    }
+
+    // NOTE: We consider arm broken if it's very near max degrees.
+    private boolean isBroken(double simArmDegrees) {
+        return simArmDegrees <= m_rangesPhysicalAndSim.getMinSimDegrees() + m_epsilonBrokenDegrees
+            || simArmDegrees >= m_rangesPhysicalAndSim.getMaxSimDegrees() - m_epsilonBrokenDegrees;
     }
 
     private MechanismLigament2d createArmLigament(Mechanism2d mech2d) {
@@ -50,7 +70,7 @@ public class ArmDisplay {
         MechanismLigament2d armTower = armPivot
             .append(new MechanismLigament2d("ArmTower", 20, -90));
         MechanismLigament2d armLigament = armPivot.append(
-            new MechanismLigament2d("Arm", 15, 0, 6, new Color8Bit(Color.kYellow)));
+            new MechanismLigament2d("Arm", 15, 0, 6, m_defaultArmColor));
 
         return armLigament;
     }

--- a/src/main/java/frc/robot/ramenlib/sim/simutil/RangeConvert.java
+++ b/src/main/java/frc/robot/ramenlib/sim/simutil/RangeConvert.java
@@ -90,7 +90,7 @@ public class RangeConvert {
      */
     public double simToPhysical(double simDegrees) {
         if (simDegrees < m_minSimDegrees || simDegrees > m_maxSimDegrees) {
-            System.out.println("ERROR: simDegrees is out of range");
+            //System.out.println("ERROR: simDegrees is out of range");
         }
 
         // Converts from simulation degrees to physical arm degrees
@@ -113,7 +113,7 @@ public class RangeConvert {
     public double physicalToSim(double physicalDegrees) {
         if (physicalDegrees < m_minPhysicalArmDegrees
             || physicalDegrees > m_maxPhysicalArmDegrees) {
-            System.out.println("ERROR: armDegrees is out of range");
+            //System.out.println("ERROR: armDegrees is out of range");
         }
 
         // converts from physical arm degrees to simulation degrees


### PR DESCRIPTION
This pull request introduces enhancements to the `ArmDisplay` class for better simulation visualization and makes minor adjustments to the `RangeConvert` class. The key changes include adding a visual indicator for arm status (default or broken) and clamping the arm's display angle to a valid range. Additionally, debug messages in `RangeConvert` have been commented out.