### PR TITLE
Suppress warnings for CheckStyle

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -4,16 +4,14 @@
 
 package frc.robot;
 
-import java.util.function.Supplier;
-
 import com.pathplanner.lib.config.PIDConstants;
-
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import java.util.function.Supplier;
 import swervelib.math.Matter;
 import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 
@@ -25,6 +23,7 @@ import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
  * <p>It is advised to statically import this class (or one of its inner classes) wherever the
  * constants are needed, to reduce verbosity.
  */
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public final class Constants
 {
   /**

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -51,8 +51,8 @@ public final class Constants
     // public static final String  kJsonDirectory = "pancake";
     public static final String  kJsonDirectory = "nori";
     public static final double kMaxSpeedMetersPerSecond = 5.06;
-    public static final double kRobotMass = Units.lbsToKilograms(129); // TODO: update
-    public static final Matter kChassisMatter = new Matter(new Translation3d(0, 0, Units.inchesToMeters(16)), kRobotMass); // TODO: update
+    public static final double kRobotMass = Units.lbsToKilograms(129); // $TODO update
+    public static final Matter kChassisMatter = new Matter(new Translation3d(0, 0, Units.inchesToMeters(16)), kRobotMass); // $TODO update
     public static final double kLoopTime = 0.13; //s, 20ms + 110ms sprk max velocity lag
   }
   /**
@@ -183,7 +183,7 @@ public final class Constants
   public static final class ElevatorConstants {
   public static final int kLeaderMotorID = 30; 
   public static final int kFollowMotorID = 31; 
-  public static final int kDIOIndex = 1; // TODO: placeholder 
+  public static final int kDIOIndex = 1; // $TODO placeholder 
   public static final int kStallLimit = 20; 
   public static final double kMaxOutputPercentage = 1; 
   //Elevator moves 5.625 in (0.1429 m) per rotation of the sprocket, gear ratio of 12:1 
@@ -204,7 +204,7 @@ public final class Constants
 
   public static final class ElevatorDefaultCommandConstants{
     // In centimeters
-    public static final double kElevatorSpeed = 0.5; //TODO: placeholder
+    public static final double kElevatorSpeed = 0.5; // $TODO placeholder
   }
   
   public static final class OuttakeConstants {

--- a/src/main/java/frc/robot/Main.java
+++ b/src/main/java/frc/robot/Main.java
@@ -11,6 +11,7 @@ import edu.wpi.first.wpilibj.RobotBase;
  * you are doing, do not modify this file except to change the parameter class to the startRobot
  * call.
  */
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public final class Main {
   private Main() {}
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -18,6 +18,7 @@ import frc.robot.ramenlib.logging.TriviaLogger;
  * build.gradle file in the
  * project.
  */
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class Robot extends TimedRobot {
   private Command m_autonomousCommand;
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,13 +4,31 @@
 
 package frc.robot;
 
-import frc.robot.Constants.ElevatorConstants;
+import com.pathplanner.lib.auto.NamedCommands;
+import edu.wpi.first.units.measure.Time;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Filesystem;
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.ConditionalCommand;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants.ArmConstants;
 import frc.robot.Constants.AutoNameConstants;
 import frc.robot.Constants.CommandConstants;
+import frc.robot.Constants.CommandConstants.AlignRobotConstants;
+import frc.robot.Constants.ElevatorConstants;
 import frc.robot.Constants.IntakeSpitCommandConstants;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.Constants.OuttakeSpitCommandConstants;
+import frc.robot.Constants.SwerveConstants;
 import frc.robot.commands.ArmDefaultCommand;
 import frc.robot.commands.ControllerRumbleCommand;
 import frc.robot.commands.DriveForwardCommand;
@@ -18,8 +36,6 @@ import frc.robot.commands.DriveForwardNow;
 import frc.robot.commands.ElevatorDefaultCommand;
 import frc.robot.commands.ElevatorManualCommand;
 import frc.robot.commands.ElevatorToPositionCommand;
-import frc.robot.Constants.SwerveConstants;
-import frc.robot.Constants.CommandConstants.AlignRobotConstants;
 import frc.robot.commands.IntakeDefaultCommand;
 import frc.robot.commands.IntakeSpitCommand;
 import frc.robot.commands.OuttakeSpitCommand;
@@ -38,33 +54,17 @@ import frc.robot.subsystems.OuttakeSystem;
 import frc.robot.subsystems.SwerveSubsystem;
 import frc.robot.util.AutoLogic;
 import frc.robot.util.CommandAppliedController;
+import java.io.File;
 import swervelib.SwerveInputStream;
 
-import java.io.File;
-
-import com.pathplanner.lib.auto.NamedCommands;
-
-import edu.wpi.first.units.measure.Time;
-import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.Filesystem;
-import edu.wpi.first.wpilibj.RobotBase;
-import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
-import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
-import edu.wpi.first.wpilibj2.command.ConditionalCommand;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import edu.wpi.first.wpilibj2.command.WaitCommand;
-import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
-
 /**
- * This class is where the bulk of the robot should be declared. Since Command-based is a "declarative" paradigm, very
- * little robot logic should actually be handled in the {@link Robot} periodic methods (other than the scheduler calls).
- * Instead, the structure of the robot (including subsystems, commands, and trigger mappings) should be declared here.
+ * This class is where the bulk of the robot should be declared. Since Command-based
+ * is a "declarative" paradigm, very little robot logic should actually be handled
+ * in the {@link Robot} periodic methods (other than the scheduler calls).
+ * Instead, the structure of the robot (including subsystems, commands, and trigger
+ * mappings) should be declared here.
  */
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class RobotContainer
 {
   private final CommandAppliedController m_driverController =

--- a/src/main/java/frc/robot/commands/AbsoluteDrive.java
+++ b/src/main/java/frc/robot/commands/AbsoluteDrive.java
@@ -19,6 +19,7 @@ import swervelib.math.SwerveMath;
 /**
  * An example command that uses an example subsystem.
  */
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class AbsoluteDrive extends Command
 {
 

--- a/src/main/java/frc/robot/commands/AimAtLimeLightV2.java
+++ b/src/main/java/frc/robot/commands/AimAtLimeLightV2.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.CommandConstants.AimAtLimeLightV2Constants;
 import frc.robot.subsystems.SwerveSubsystem;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class AimAtLimeLightV2 extends Command {
     private SwerveSubsystem m_swerveDrive;
     private Timer m_timer = new Timer();

--- a/src/main/java/frc/robot/commands/ArmDefaultCommand.java
+++ b/src/main/java/frc/robot/commands/ArmDefaultCommand.java
@@ -1,14 +1,14 @@
 package frc.robot.commands;
 
-import java.util.function.Supplier;
-
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.ArmConstants;
 import frc.robot.Constants.ArmDefaultCommandConstants;
 import frc.robot.subsystems.IntakeArmSystem;
+import java.util.function.Supplier;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class ArmDefaultCommand extends Command {
     private IntakeArmSystem m_armSystem;
     private Supplier<Double> m_deltaArmAngleFromController;

--- a/src/main/java/frc/robot/commands/ArmTestCommand.java
+++ b/src/main/java/frc/robot/commands/ArmTestCommand.java
@@ -1,11 +1,11 @@
 package frc.robot.commands; 
- 
-import java.util.function.Supplier; 
- 
+
 import edu.wpi.first.wpilibj2.command.Command; 
 import frc.robot.subsystems.IntakeArmSystem; 
+import java.util.function.Supplier; 
  
 //Command for testing arm woithout relying on PID 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class ArmTestCommand extends Command { 
     private IntakeArmSystem m_armSystem; 
     private Supplier<Double> m_deltaArmAngleFromController; 

--- a/src/main/java/frc/robot/commands/Autos.java
+++ b/src/main/java/frc/robot/commands/Autos.java
@@ -4,10 +4,11 @@
 
 package frc.robot.commands;
 
-import frc.robot.subsystems.ExampleSubsystem;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.subsystems.ExampleSubsystem;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public final class Autos {
   /** Example static factory for an autonomous command. */
   public static Command exampleAuto(ExampleSubsystem subsystem) {

--- a/src/main/java/frc/robot/commands/ControllerRumbleCommand.java
+++ b/src/main/java/frc/robot/commands/ControllerRumbleCommand.java
@@ -5,6 +5,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.util.CommandAppliedController;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class ControllerRumbleCommand extends Command {
     private double m_time;
     private double m_intensity;

--- a/src/main/java/frc/robot/commands/DriveForwardCommand.java
+++ b/src/main/java/frc/robot/commands/DriveForwardCommand.java
@@ -7,6 +7,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.SwerveSubsystem;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class DriveForwardCommand extends Command {
     private SwerveSubsystem m_swerveDrive;
     private double startX;

--- a/src/main/java/frc/robot/commands/DriveForwardNow.java
+++ b/src/main/java/frc/robot/commands/DriveForwardNow.java
@@ -7,8 +7,8 @@ package frc.robot.commands;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.subsystems.SwerveSubsystem;
@@ -16,6 +16,7 @@ import frc.robot.subsystems.SwerveSubsystem;
 /**
  * An example command that uses an example subsystem.
  */
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class DriveForwardNow extends Command
 {
   private final SwerveSubsystem m_swerve;

--- a/src/main/java/frc/robot/commands/ElevatorDefaultCommand.java
+++ b/src/main/java/frc/robot/commands/ElevatorDefaultCommand.java
@@ -1,13 +1,13 @@
 package frc.robot.commands;
 
-import java.util.function.DoubleSupplier;
-
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.ElevatorConstants;
 import frc.robot.Constants.ElevatorDefaultCommandConstants;
 import frc.robot.subsystems.ElevatorSystem;
+import java.util.function.DoubleSupplier;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class ElevatorDefaultCommand extends Command{
     private ElevatorSystem m_elevator;
     private DoubleSupplier m_joystick;

--- a/src/main/java/frc/robot/commands/ElevatorManualCommand.java
+++ b/src/main/java/frc/robot/commands/ElevatorManualCommand.java
@@ -1,7 +1,5 @@
 package frc.robot.commands;
 
-import java.util.function.Supplier;
-
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -9,7 +7,9 @@ import frc.robot.Constants.ArmConstants;
 import frc.robot.Constants.ArmDefaultCommandConstants;
 import frc.robot.subsystems.ElevatorSystem;
 import frc.robot.subsystems.IntakeArmSystem;
+import java.util.function.Supplier;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class ElevatorManualCommand extends Command {
     private ElevatorSystem m_elevatorSystem;
     private Supplier<Double> m_deltaArmAngleFromController;

--- a/src/main/java/frc/robot/commands/ElevatorToPositionCommand.java
+++ b/src/main/java/frc/robot/commands/ElevatorToPositionCommand.java
@@ -6,6 +6,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.ElevatorConstants;
 import frc.robot.subsystems.ElevatorSystem;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class ElevatorToPositionCommand extends Command{
     private ElevatorSystem m_elevator;
     private double m_desiredPosition;

--- a/src/main/java/frc/robot/commands/ExampleCommand.java
+++ b/src/main/java/frc/robot/commands/ExampleCommand.java
@@ -4,10 +4,11 @@
 
 package frc.robot.commands;
 
-import frc.robot.subsystems.ExampleSubsystem;
 import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.ExampleSubsystem;
 
 /** An example command that uses an example subsystem. */
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class ExampleCommand extends Command {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
   private final ExampleSubsystem m_subsystem;

--- a/src/main/java/frc/robot/commands/IntakeDefaultCommand.java
+++ b/src/main/java/frc/robot/commands/IntakeDefaultCommand.java
@@ -1,8 +1,10 @@
 package frc.robot.commands;
+
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.IntakeDefaultCommandConstants;
 import frc.robot.subsystems.IntakeSystem;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class IntakeDefaultCommand extends Command {
     private IntakeSystem m_intake;
 

--- a/src/main/java/frc/robot/commands/IntakeSpitCommand.java
+++ b/src/main/java/frc/robot/commands/IntakeSpitCommand.java
@@ -6,6 +6,7 @@ import frc.robot.Constants.IntakeConstants;
 import frc.robot.Constants.IntakeSpitCommandConstants;
 import frc.robot.subsystems.IntakeSystem;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class IntakeSpitCommand extends Command {
     private IntakeSystem m_intake;
     private Timer m_timer = new Timer();

--- a/src/main/java/frc/robot/commands/IntakeTestCommand.java
+++ b/src/main/java/frc/robot/commands/IntakeTestCommand.java
@@ -4,6 +4,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.IntakeSystem;
 
 //IMPORTANT: Just for testing. Not real command.
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class IntakeTestCommand extends Command{
     private IntakeSystem m_intake;
 

--- a/src/main/java/frc/robot/commands/LeftSideDriveToRight.java
+++ b/src/main/java/frc/robot/commands/LeftSideDriveToRight.java
@@ -7,6 +7,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.SwerveSubsystem;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class LeftSideDriveToRight extends Command {
     private final SwerveSubsystem m_swerve;
     private Timer m_timer = new Timer();

--- a/src/main/java/frc/robot/commands/OuttakeSpitCommand.java
+++ b/src/main/java/frc/robot/commands/OuttakeSpitCommand.java
@@ -6,6 +6,7 @@ import frc.robot.Constants.OuttakeConstants;
 import frc.robot.Constants.OuttakeSpitCommandConstants;
 import frc.robot.subsystems.OuttakeSystem;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class OuttakeSpitCommand extends Command {
     private OuttakeSystem m_outtake;
     private Timer m_timer = new Timer();

--- a/src/main/java/frc/robot/commands/SetArmToAngleCommand.java
+++ b/src/main/java/frc/robot/commands/SetArmToAngleCommand.java
@@ -6,6 +6,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.ArmConstants;
 import frc.robot.subsystems.IntakeArmSystem;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class SetArmToAngleCommand extends Command {
     private IntakeArmSystem m_armSystem;
     private Timer m_timer = new Timer();

--- a/src/main/java/frc/robot/subsystems/ElevatorSystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSystem.java
@@ -1,28 +1,26 @@
 package frc.robot.subsystems;
 
-import com.revrobotics.spark.SparkMax;
-import com.revrobotics.spark.config.ClosedLoopConfig;
-import com.revrobotics.spark.config.EncoderConfig;
-import com.revrobotics.spark.config.SparkBaseConfig;
-import com.revrobotics.spark.config.SparkMaxConfig;
-
-import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.wpilibj.DigitalInput;
-import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
-import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
-
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkBase;
 import com.revrobotics.spark.SparkBase.ControlType;
 import com.revrobotics.spark.SparkClosedLoopController;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
-
-import frc.robot.Constants.OperatorConstants;
-import frc.robot.ramenlib.logging.TriviaLogger;
+import com.revrobotics.spark.SparkMax;
+import com.revrobotics.spark.config.ClosedLoopConfig;
+import com.revrobotics.spark.config.EncoderConfig;
+import com.revrobotics.spark.config.SparkBaseConfig;
+import com.revrobotics.spark.config.SparkMaxConfig;
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.ElevatorConstants;
 import frc.robot.Constants.IntakeConstants;
+import frc.robot.Constants.OperatorConstants;
+import frc.robot.ramenlib.logging.TriviaLogger;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class ElevatorSystem extends SubsystemBase{
     //Motors are on opposite sides of a shaft
     private final SparkMax m_leaderMotor = new SparkMax(ElevatorConstants.kLeaderMotorID, MotorType.kBrushless);

--- a/src/main/java/frc/robot/subsystems/ExampleSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ExampleSubsystem.java
@@ -7,6 +7,7 @@ package frc.robot.subsystems;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class ExampleSubsystem extends SubsystemBase {
   /** Creates a new ExampleSubsystem. */
   public ExampleSubsystem() {}

--- a/src/main/java/frc/robot/subsystems/IntakeArmSystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeArmSystem.java
@@ -2,15 +2,14 @@ package frc.robot.subsystems;
  
 import com.revrobotics.RelativeEncoder; 
 import com.revrobotics.spark.SparkBase; 
+import com.revrobotics.spark.SparkBase.ControlType; 
 import com.revrobotics.spark.SparkClosedLoopController; 
 import com.revrobotics.spark.SparkLowLevel.MotorType; 
+import com.revrobotics.spark.SparkMax; 
 import com.revrobotics.spark.config.ClosedLoopConfig; 
 import com.revrobotics.spark.config.EncoderConfig; 
 import com.revrobotics.spark.config.SparkBaseConfig; 
 import com.revrobotics.spark.config.SparkMaxConfig; 
-import com.revrobotics.spark.SparkMax; 
-import com.revrobotics.spark.SparkBase.ControlType; 
- 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
@@ -21,7 +20,7 @@ import edu.wpi.first.wpilibj.simulation.DutyCycleEncoderSim;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase; 
- 
+import frc.robot.Constants.ArmConstants;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.SetArmToAngleCommand;
 import frc.robot.ramenlib.logging.TriviaLogger;
@@ -31,9 +30,8 @@ import frc.robot.ramenlib.sim.armsimulation.IOArmSim;
 import frc.robot.ramenlib.sim.armsimulation.IOArmSimInterface;
 import frc.robot.ramenlib.sim.simutil.RangeConvert;
 import frc.robot.ramenlib.sim.simutil.RelativeEncoderSim;
-import frc.robot.Constants.ArmConstants;
  
- 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class IntakeArmSystem extends SubsystemBase{ 
     private SparkMax m_armMotor = new SparkMax(ArmConstants.kArmMotorID, MotorType.kBrushless); 
     private RelativeEncoder m_armRelativeEncoder = m_armMotor.getEncoder(); 

--- a/src/main/java/frc/robot/subsystems/IntakeSystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSystem.java
@@ -3,20 +3,19 @@ package frc.robot.subsystems;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkBase;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
+import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.SparkBaseConfig;
 import com.revrobotics.spark.config.SparkMaxConfig;
-import com.revrobotics.spark.SparkMax;
-
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-
+import frc.robot.Constants.IntakeConstants;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.ramenlib.logging.TriviaLogger;
-import frc.robot.Constants.IntakeConstants;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class IntakeSystem extends SubsystemBase{
     //the front motor, for pulling the coarl in and scoring on L1
     private SparkMax m_pullMotor = new SparkMax(IntakeConstants.kPullMotorID, MotorType.kBrushless);

--- a/src/main/java/frc/robot/subsystems/OuttakeSystem.java
+++ b/src/main/java/frc/robot/subsystems/OuttakeSystem.java
@@ -3,20 +3,19 @@ package frc.robot.subsystems;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkBase;
 import com.revrobotics.spark.SparkFlex;
+import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.SparkBaseConfig;
 import com.revrobotics.spark.config.SparkFlexConfig;
 import com.revrobotics.spark.config.SparkMaxConfig;
-import com.revrobotics.spark.SparkLowLevel.MotorType;
-
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.Constants.OuttakeConstants;
 import frc.robot.ramenlib.logging.TriviaLogger;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class OuttakeSystem extends SubsystemBase {
     private SparkFlex m_outtakeSparkFlex = new SparkFlex(OuttakeConstants.sparkflexID, MotorType.kBrushless);
     private SparkMax m_outtakeSparkMax = new SparkMax(OuttakeConstants.sparkmaxID, MotorType.kBrushless);

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -27,8 +27,8 @@ import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
@@ -40,17 +40,16 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Config;
 import frc.robot.Constants.CommandConstants.AlignRobotConstants;
+import frc.robot.Constants.OperatorConstants;
+import frc.robot.Constants.SwerveConstants;
+import frc.robot.Robot;
 import frc.robot.ramenlib.logging.TriviaLogger;
 import frc.robot.ramenlib.sim.simvision.VisionSim;
 import frc.robot.ramenlib.sim.simvision.VisionSystemInterface;
 import frc.robot.ramenlib.sim.simvision.VisionSystemSim;
 import frc.robot.ramenlib.wheelcalibration.CalibrationOrchestrator;
-import frc.robot.Constants.OperatorConstants;
-import frc.robot.Constants.SwerveConstants;
-import frc.robot.Robot;
 import frc.robot.util.AutoLogic;
 import frc.robot.vision.VisionSystem;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -68,6 +67,7 @@ import swervelib.parser.SwerveParser;
 import swervelib.telemetry.SwerveDriveTelemetry;
 import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class SwerveSubsystem extends SubsystemBase
 {
 
@@ -565,6 +565,7 @@ public class SwerveSubsystem extends SubsystemBase
                            .forEach(it -> it.setAngle(0.0)));
   }
 
+  @SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
   public Supplier<Command> driveMeters(double distanceInMeters, double speedInMetersPerSecond) {
     return () -> {
       double startX = getPose().getX();

--- a/src/main/java/frc/robot/util/AutoLogic.java
+++ b/src/main/java/frc/robot/util/AutoLogic.java
@@ -16,11 +16,11 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.Constants.AutoNameConstants;
-
 import java.io.IOException;
 import java.util.List;
 import org.json.simple.parser.ParseException;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class AutoLogic {
   public static SendableChooser<String> autoPicker = new SendableChooser<String>();
 

--- a/src/main/java/frc/robot/util/CommandAppliedController.java
+++ b/src/main/java/frc/robot/util/CommandAppliedController.java
@@ -8,6 +8,7 @@ import frc.robot.Constants.OperatorConstants;
 /**
  * AppliedController.
  */
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class CommandAppliedController extends CommandXboxController {
 
     private double m_controllerExponent; //expo factor for the analog axises

--- a/src/main/java/frc/robot/vision/LimelightHelpers.java
+++ b/src/main/java/frc/robot/vision/LimelightHelpers.java
@@ -2,38 +2,38 @@
 
 package frc.robot.vision;
 
-import edu.wpi.first.networktables.DoubleArrayEntry;
-import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.networktables.TimestampedDoubleArray;
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Translation3d;
-import edu.wpi.first.math.util.Units;
-import edu.wpi.first.math.geometry.Rotation3d;
-import edu.wpi.first.math.geometry.Translation2d;
-
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.networktables.DoubleArrayEntry;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.TimestampedDoubleArray;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * LimelightHelpers provides static methods and classes for interfacing with Limelight vision cameras in FRC.
- * This library supports all Limelight features including AprilTag tracking, Neural Networks, and standard color/retroreflective tracking.
+ * LimelightHelpers provides static methods and classes for interfacing with
+ * Limelight vision cameras in FRC. This library supports all Limelight features
+ * including AprilTag tracking, Neural Networks, and standard color/retroreflective tracking.
  */
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class LimelightHelpers {
 
     private static final Map<String, DoubleArrayEntry> doubleArrayEntries = new ConcurrentHashMap<>();

--- a/src/main/java/frc/robot/vision/VisionSystem.java
+++ b/src/main/java/frc/robot/vision/VisionSystem.java
@@ -11,6 +11,7 @@ import frc.robot.Constants.OperatorConstants;
 import frc.robot.Constants.VisionConstants;
 import frc.robot.ramenlib.sim.simvision.VisionSystemInterface;
 
+@SuppressWarnings({"all"}) // suppress CheckStyle warnings in this file
 public class VisionSystem implements VisionSystemInterface {
 
     private NetworkTable m_limelightTable = NetworkTableInstance.getDefault()


### PR DESCRIPTION
Added CheckStyle, and cleaned up all warnings under ramenlib.  However, I avoided making hundreds of fixes accross the main Robot files, since then it would be a pain for everyone to merge with those files.  So instead, there's a @suppress at the top of every Robot file - we can remove these suppressions file-by-file as individual files are fixed.